### PR TITLE
Fix idle pg connection crash

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -33,6 +33,12 @@ Sentry.init({
 
 const client = new pg.Pool({ connectionString: DATABASE_URL })
 await client.connect()
+client.on('error', err => {
+  // Prevent crashing the process on idle client errors, the pool will recover
+  // itself. If all connections are lost, the process will still crash.
+  // https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405
+  console.error('An idle client has experienced an error', err.stack)
+})
 const handler = await createHandler({ client, logger: console })
 const server = http.createServer(handler)
 server.listen(PORT)


### PR DESCRIPTION
See https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405

Fixes crashes like:

```
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] Error: Connection terminated unexpectedly
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Connection.<anonymous> (/app/node_modules/pg/lib/client.js:132:73)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Object.onceWrapper (node:events:627:28)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Connection.emit (node:events:513:28)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Connection.emit (node:domain:489:12)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Socket.<anonymous> (/app/node_modules/pg/lib/connection.js:63:12)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Socket.emit (node:events:513:28)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at Socket.emit (node:domain:489:12)
2023-07-25T08:22:40.841 app[17814d5b527638] cdg [info] at TCP.<anonymous> (node:net:301:12)
```