### PR TITLE
feat: add round & IP address to data model

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -31,6 +31,11 @@ Sentry.init({
   tracesSampleRate: 0.1
 })
 
+const getCurrentRound = async () => {
+  // TBD
+  return 0
+}
+
 const client = new pg.Pool({ connectionString: DATABASE_URL })
 await client.connect()
 client.on('error', err => {
@@ -39,7 +44,7 @@ client.on('error', err => {
   // https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405
   console.error('An idle client has experienced an error', err.stack)
 })
-const handler = await createHandler({ client, logger: console })
+const handler = await createHandler({ client, logger: console, getCurrentRound })
 const server = http.createServer(handler)
 server.listen(PORT)
 await once(server, 'listening')

--- a/migrations/012.do.round-and-ip-address.sql
+++ b/migrations/012.do.round-and-ip-address.sql
@@ -1,0 +1,15 @@
+-- bigint uses 64 bits, the upper limit is +9223372036854775807
+-- Postgres and SQL do not support unsigned integers
+ALTER TABLE retrievals ADD COLUMN created_at_round BIGINT;
+ALTER TABLE retrievals ADD COLUMN created_from_address INET;
+
+UPDATE retrievals SET created_at_round = 0, created_from_address = '0.0.0.0';
+ALTER TABLE retrievals ALTER COLUMN created_at_round SET NOT NULL;
+ALTER TABLE retrievals ALTER COLUMN created_from_address SET NOT NULL;
+
+ALTER TABLE retrieval_results ADD COLUMN completed_at_round BIGINT;
+ALTER TABLE retrieval_results ADD COLUMN completed_from_address INET;
+
+UPDATE retrieval_results SET completed_at_round = 0, completed_from_address = '0.0.0.0';
+ALTER TABLE retrieval_results ALTER COLUMN completed_at_round SET NOT NULL;
+ALTER TABLE retrieval_results ALTER COLUMN completed_from_address SET NOT NULL;

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,10 @@ describe('Routes', () => {
       logger: {
         info () {},
         error (...args) { console.error(...args) }
+      },
+      async getCurrentRound () {
+        // TBD
+        return 42
       }
     })
     server = http.createServer(handler)


### PR DESCRIPTION
Add two new columns to `retrievals` table:
```
created_at_round BIGINT NOT NULL
created_from_address INET NOT NULL
```

Add two new columns to `retrieval_results` table:
```
completed_at_round BIGINT NOT NULL
completed_from_address INET NOT NULL
```

Rework the HTTP handler and the test suite to fill these new columns, using a hard-coded round number (for now).

For the existing rows, use round `0` and address `0.0.0.0`.

_This is the first step towards https://github.com/filecoin-station/spark/issues/13._
