### PR TITLE
feat: add round number to the data model

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -31,6 +31,11 @@ Sentry.init({
   tracesSampleRate: 0.1
 })
 
+const getCurrentRound = async () => {
+  // TBD
+  return 0
+}
+
 const client = new pg.Pool({ connectionString: DATABASE_URL })
 await client.connect()
 client.on('error', err => {
@@ -39,7 +44,7 @@ client.on('error', err => {
   // https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405
   console.error('An idle client has experienced an error', err.stack)
 })
-const handler = await createHandler({ client, logger: console })
+const handler = await createHandler({ client, logger: console, getCurrentRound })
 const server = http.createServer(handler)
 server.listen(PORT)
 await once(server, 'listening')

--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ import getRawBody from 'raw-body'
 import assert from 'http-assert'
 import { validate } from './lib/validate.js'
 
-const handler = async (req, res, client) => {
+const handler = async (req, res, client, getCurrentRound) => {
   const segs = req.url.split('/').filter(Boolean)
   if (segs[0] === 'retrievals' && req.method === 'POST') {
-    await createRetrieval(req, res, client)
+    await createRetrieval(req, res, client, getCurrentRound)
   } else if (segs[0] === 'retrievals' && req.method === 'PATCH') {
-    await setRetrievalResult(req, res, client, Number(segs[1]))
+    await setRetrievalResult(req, res, client, Number(segs[1]), getCurrentRound)
   } else if (segs[0] === 'retrievals' && req.method === 'GET') {
     await getRetrieval(req, res, client, Number(segs[1]))
   } else {
@@ -17,7 +17,8 @@ const handler = async (req, res, client) => {
   }
 }
 
-const createRetrieval = async (req, res, client) => {
+const createRetrieval = async (req, res, client, getCurrentRound) => {
+  const round = await getCurrentRound()
   const body = await getRawBody(req, { limit: '100kb' })
   const meta = body.length > 0 ? JSON.parse(body) : {}
   validate(meta, 'sparkVersion', { type: 'string', required: false })
@@ -36,14 +37,16 @@ const createRetrieval = async (req, res, client) => {
     INSERT INTO retrievals (
       retrieval_template_id,
       spark_version,
-      zinnia_version
+      zinnia_version,
+      created_at_round
     )
-    VALUES ($1, $2, $3)
+    VALUES ($1, $2, $3, $4)
     RETURNING id
   `, [
     retrievalTemplate.id,
     meta.sparkVersion,
-    meta.zinniaVersion
+    meta.zinniaVersion,
+    round
   ])
   json(res, {
     id: retrieval.id,
@@ -53,7 +56,8 @@ const createRetrieval = async (req, res, client) => {
   })
 }
 
-const setRetrievalResult = async (req, res, client, retrievalId) => {
+const setRetrievalResult = async (req, res, client, retrievalId, getCurrentRound) => {
+  const round = await getCurrentRound()
   assert(!Number.isNaN(retrievalId), 400, 'Invalid Retrieval ID')
   const body = await getRawBody(req, { limit: '100kb' })
   const result = JSON.parse(body)
@@ -78,10 +82,11 @@ const setRetrievalResult = async (req, res, client, retrievalId) => {
         first_byte_at,
         end_at,
         byte_length,
-        attestation
+        attestation,
+        completed_at_round
       )
       VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
       )
     `, [
       retrievalId,
@@ -93,7 +98,8 @@ const setRetrievalResult = async (req, res, client, retrievalId) => {
       new Date(result.firstByteAt),
       new Date(result.endAt),
       result.byteLength,
-      result.attestation
+      result.attestation,
+      round
     ])
   } catch (err) {
     if (err.constraint === 'retrieval_results_retrieval_id_fkey') {
@@ -169,12 +175,12 @@ const errorHandler = (res, err, logger) => {
   }
 }
 
-export const createHandler = async ({ client, logger }) => {
+export const createHandler = async ({ client, logger, getCurrentRound }) => {
   await migrate(client)
   return (req, res) => {
     const start = new Date()
     logger.info(`${req.method} ${req.url} ...`)
-    handler(req, res, client)
+    handler(req, res, client, getCurrentRound)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
         logger.info(`${req.method} ${req.url} ${res.statusCode} (${new Date() - start}ms)`)

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,12 @@ describe('Routes', () => {
       logger: {
         info () {},
         error (...args) { console.error(...args) }
+      },
+      async getCurrentRound () {
+        // TBD
+        // We return a string because 64bit integers JavaScript `number` cannot
+        // represent all 64bit values
+        return '42'
       }
     })
     server = http.createServer(handler)
@@ -60,6 +66,12 @@ describe('Routes', () => {
       assert.strictEqual(typeof body.cid, 'string')
       assert.strictEqual(typeof body.providerAddress, 'string')
       assert.strictEqual(typeof body.protocol, 'string')
+
+      const { rows: [retrievalRow] } = await client.query(
+        'SELECT * FROM retrievals WHERE id = $1',
+        [body.id]
+      )
+      assert.strictEqual(retrievalRow.created_at_round, '42')
     })
     it('uses random retrieval templates', async () => {
       const makeRequest = async () => {
@@ -178,6 +190,7 @@ describe('Routes', () => {
       )
       assert.strictEqual(retrievalResultRow.byte_length, result.byteLength)
       assert.strictEqual(retrievalResultRow.attestation, result.attestation)
+      assert.strictEqual(retrievalResultRow.completed_at_round, '42')
     })
     it('handles invalid JSON', async () => {
       const { id: retrievalId } = await givenRetrieval()


### PR DESCRIPTION
Add a new column to `retrievals` table:
```
created_at_round BIGINT NOT NULL
```

Add a new column to `retrieval_results` table:
```
completed_at_round BIGINT NOT NULL
```

Rework the HTTP handler and the test suite to fill these new columns,
using a hard-coded round number (for now).

_This is the first step towards filecoin-station/spark#13. It replaces #56._
