### PR TITLE
feat: add IP address to the data model

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const createRetrieval = async (req, res, client, getCurrentRound) => {
     meta.sparkVersion,
     meta.zinniaVersion,
     round,
-    req.connection.remoteAddress
+    getClientAddress(req)
   ])
   json(res, {
     id: retrieval.id,
@@ -103,7 +103,7 @@ const setRetrievalResult = async (req, res, client, retrievalId, getCurrentRound
       result.byteLength,
       result.attestation,
       round,
-      req.connection.remoteAddress
+      getClientAddress(req)
     ])
   } catch (err) {
     if (err.constraint === 'retrieval_results_retrieval_id_fkey') {
@@ -178,6 +178,8 @@ const errorHandler = (res, err, logger) => {
     res.end('Internal Server Error')
   }
 }
+
+const getClientAddress = (req) => req.headers['fly-client-ip'] ?? req.connection.remoteAddress
 
 export const createHandler = async ({ client, logger, getCurrentRound }) => {
   await migrate(client)

--- a/index.js
+++ b/index.js
@@ -36,14 +36,18 @@ const createRetrieval = async (req, res, client) => {
     INSERT INTO retrievals (
       retrieval_template_id,
       spark_version,
-      zinnia_version
+      zinnia_version,
+      created_at_round,
+      created_from_address
     )
-    VALUES ($1, $2, $3)
+    VALUES ($1, $2, $3, $4, $5)
     RETURNING id
   `, [
     retrievalTemplate.id,
     meta.sparkVersion,
-    meta.zinniaVersion
+    meta.zinniaVersion,
+    round,
+    req.connection.remoteAddress
   ])
   json(res, {
     id: retrieval.id,
@@ -78,10 +82,12 @@ const setRetrievalResult = async (req, res, client, retrievalId) => {
         first_byte_at,
         end_at,
         byte_length,
-        attestation
+        attestation,
+        completed_at_round,
+        completed_from_address
       )
       VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
       )
     `, [
       retrievalId,
@@ -93,7 +99,9 @@ const setRetrievalResult = async (req, res, client, retrievalId) => {
       new Date(result.firstByteAt),
       new Date(result.endAt),
       result.byteLength,
-      result.attestation
+      result.attestation,
+      round,
+      req.connection.remoteAddress
     ])
   } catch (err) {
     if (err.constraint === 'retrieval_results_retrieval_id_fkey') {

--- a/migrations/013.do.ip-address.sql
+++ b/migrations/013.do.ip-address.sql
@@ -1,6 +1,6 @@
 ALTER TABLE retrievals ADD COLUMN created_from_address INET;
 UPDATE retrievals SET created_from_address = '0.0.0.0';
-ALTER TABLE retrievals ALTER COLUMN created_at_round SET NOT NULL;
+ALTER TABLE retrievals ALTER COLUMN created_from_address SET NOT NULL;
 
 ALTER TABLE retrieval_results ADD COLUMN completed_from_address INET;
 UPDATE retrieval_results SET completed_from_address = '0.0.0.0';

--- a/migrations/013.do.ip-address.sql
+++ b/migrations/013.do.ip-address.sql
@@ -1,0 +1,7 @@
+ALTER TABLE retrievals ADD COLUMN created_from_address INET;
+UPDATE retrievals SET created_from_address = '0.0.0.0';
+ALTER TABLE retrievals ALTER COLUMN created_at_round SET NOT NULL;
+
+ALTER TABLE retrieval_results ADD COLUMN completed_from_address INET;
+UPDATE retrieval_results SET completed_from_address = '0.0.0.0';
+ALTER TABLE retrieval_results ALTER COLUMN completed_from_address SET NOT NULL;

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,13 @@ describe('Routes', () => {
       assert.strictEqual(typeof body.cid, 'string')
       assert.strictEqual(typeof body.providerAddress, 'string')
       assert.strictEqual(typeof body.protocol, 'string')
+
+      const { rows: [retrievalRow] } = await client.query(
+        'SELECT * FROM retrievals WHERE id = $1',
+        [body.id]
+      )
+      assert.strictEqual(retrievalRow.created_at_round, '42')
+      assert.strictEqual(retrievalRow.created_from_address, '127.0.0.1')
     })
     it('uses random retrieval templates', async () => {
       const makeRequest = async () => {
@@ -178,6 +185,8 @@ describe('Routes', () => {
       )
       assert.strictEqual(retrievalResultRow.byte_length, result.byteLength)
       assert.strictEqual(retrievalResultRow.attestation, result.attestation)
+      assert.strictEqual(retrievalResultRow.completed_at_round, '42')
+      assert.strictEqual(retrievalResultRow.completed_from_address, '127.0.0.1')
     })
     it('handles invalid JSON', async () => {
       const { id: retrievalId } = await givenRetrieval()


### PR DESCRIPTION
Add a new column to `retrievals` table:
```
created_from_address INET NOT NULL
```

Add a new column to `retrieval_results` table:
```
completed_from_address INET NOT NULL
```

Rework the HTTP handler and the test suite to fill these new columns.

_This PR replaces #56, see also #58._
