### PR TITLE
test: remove delay before exit

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -39,9 +39,10 @@ describe('Routes', () => {
     spark = `http://127.0.0.1:${server.address().port}`
   })
 
-  after(() => {
+  after(async () => {
+    server.closeAllConnections()
     server.close()
-    client.end()
+    await client.end()
   })
 
   describe('GET /', () => {


### PR DESCRIPTION
Before my change, the mocha process would print test summary and then wait for around two seconds before exiting.

In this change, I am adding a call to `server.closeAllConnections()` to make sure there are no pending HTTP connections blocking the exit.

While changing the `after` hook, I also fixed it to `await` until the PG client is closed.
