### PR TITLE
fix: wait for current round before starting

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -44,7 +44,7 @@ client.on('error', err => {
 
 const getCurrentRound = await createRoundGetter(client)
 
-const round = await getCurrentRound();
+const round = await getCurrentRound()
 assert(!!round, 'cannot obtain the current Spark round number')
 console.log('SPARK round number at service startup:', round)
 

--- a/bin/spark.js
+++ b/bin/spark.js
@@ -7,6 +7,7 @@ import fs from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRoundGetter } from '../lib/round-tracker.js'
+import assert from 'node:assert'
 
 const {
   PORT = 8080,
@@ -42,6 +43,11 @@ client.on('error', err => {
 })
 
 const getCurrentRound = await createRoundGetter(client)
+
+const round = await getCurrentRound();
+assert(!!round, 'cannot obtain the current Spark round number')
+console.log('SPARK round number at service startup:', round)
+
 const handler = await createHandler({ client, logger: console, getCurrentRound })
 const server = http.createServer(handler)
 server.listen(PORT)

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -21,7 +21,7 @@ export async function createRoundGetter (pgClient) {
     })
   })
 
-  updateSparkRound(await contract.currentRoundIndex())
+  await updateSparkRound(await contract.currentRoundIndex())
 
   return () => sparkRoundNumber
 }


### PR DESCRIPTION
I am seeing all `POST /retrievals` request failing with the following
error:

```
error: null value in column "created_at_round" of relation "retrievals" violates not-null constraint
```

This commit tries to fix the problem by adding a forgotten `await`
statement to the code initialising the round tracker.

The problem was introduced by https://github.com/filecoin-station/spark-api/pull/61
