### PR TITLE
bump MAX_MEASUREMENTS_PER_ROUND to 2000

### DIFF
--- a/spark-publish/Dockerfile
+++ b/spark-publish/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 # Set production environment
 ENV NODE_ENV="production"
 ENV SENTRY_ENVIRONMMENT="production"
+ENV MAX_MEASUREMENTS_PER_ROUND=2000
 
 # Throw-away build stage to reduce size of final image
 FROM base as build


### PR DESCRIPTION
We're comfortably processing batches of 1000, let's bump to 2000. See https://fly.io/apps/spark-publish/metrics for metrics