### PR TITLE
feat: decouple retrieval results from retrievals

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const handler = async (req, res, client, getCurrentRound) => {
   if (segs[0] === 'retrievals' && req.method === 'POST') {
     await createRetrieval(req, res, client, getCurrentRound)
   } else if (segs[0] === 'retrievals' && req.method === 'PATCH') {
+    // TODO: Deprecate once clients have been updated
     await setRetrievalResult(req, res, client, Number(segs[1]), getCurrentRound)
   } else if (segs[0] === 'retrievals' && req.method === 'GET') {
     assert.fail(501, 'This API endpoint is no longer supported.')

--- a/index.js
+++ b/index.js
@@ -191,23 +191,7 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
 const getMeasurement = async (req, res, client, measurementId) => {
   assert(!Number.isNaN(measurementId), 400, 'Invalid RetrievalResult ID')
   const { rows: [resultRow] } = await client.query(`
-    SELECT
-      id,
-      spark_version,
-      zinnia_version,
-      finished_at,
-      success,
-      timeout,
-      start_at,
-      status_code,
-      first_byte_at,
-      end_at,
-      byte_length,
-      attestation,
-      cid,
-      provider_address,
-      protocol,
-      published_as
+    SELECT *
     FROM measurements
     WHERE id = $1
   `, [

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
         completed_at_round
       )
       VALUES (
-       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
       )
       RETURNING id
     `, [

--- a/migrations/016.do.measurements.sql
+++ b/migrations/016.do.measurements.sql
@@ -21,6 +21,7 @@ WHERE retrieval_id = retrievals.id;
 ALTER TABLE retrieval_results ALTER COLUMN cid SET NOT NULL;
 ALTER TABLE retrieval_results ALTER COLUMN provider_address SET NOT NULL;
 ALTER TABLE retrieval_results ALTER COLUMN protocol SET NOT NULL;
+ALTER TABLE retrievals DROP COLUMN published_as;
 
 -- Remove the foreign key constraint to decouple `retrieval_results` from `retrievals`
 ALTER TABLE retrieval_results DROP CONSTRAINT retrieval_results_retrieval_id_fkey;

--- a/migrations/016.do.measurements.sql
+++ b/migrations/016.do.measurements.sql
@@ -3,6 +3,7 @@ ALTER TABLE retrieval_results ADD COLUMN zinnia_version TEXT;
 ALTER TABLE retrieval_results ADD COLUMN cid TEXT;
 ALTER TABLE retrieval_results ADD COLUMN provider_address TEXT;
 ALTER TABLE retrieval_results ADD COLUMN protocol protocol;
+ALTER TABLE retrieval_results ADD COLUMN published_as TEXT;
 
 UPDATE retrieval_results
 SET
@@ -10,7 +11,8 @@ SET
   zinnia_version = retrievals.zinnia_version,
   cid = retrieval_templates.cid,
   provider_address = retrieval_templates.provider_address,
-  protocol = retrieval_templates.protocol
+  protocol = retrieval_templates.protocol,
+  published_as = retrievals.published_as
 FROM
   retrievals LEFT JOIN retrieval_templates
     ON retrievals.retrieval_template_id = retrieval_templates.id
@@ -31,4 +33,6 @@ ALTER TABLE retrieval_results
 -- Adjust the sequence to match the current maximum value
 SELECT setval(pg_get_serial_sequence('retrieval_results', 'id'), max(id))
 FROM retrieval_results;
+
+ALTER TABLE retrieval_results RENAME TO measurements;
 

--- a/migrations/016.do.standalone-retrieval-results.sql
+++ b/migrations/016.do.standalone-retrieval-results.sql
@@ -1,0 +1,34 @@
+ALTER TABLE retrieval_results ADD COLUMN spark_version TEXT;
+ALTER TABLE retrieval_results ADD COLUMN zinnia_version TEXT;
+ALTER TABLE retrieval_results ADD COLUMN cid TEXT;
+ALTER TABLE retrieval_results ADD COLUMN provider_address TEXT;
+ALTER TABLE retrieval_results ADD COLUMN protocol protocol;
+
+UPDATE retrieval_results
+SET
+  spark_version = retrievals.spark_version,
+  zinnia_version = retrievals.zinnia_version,
+  cid = retrieval_templates.cid,
+  provider_address = retrieval_templates.provider_address,
+  protocol = retrieval_templates.protocol
+FROM
+  retrievals LEFT JOIN retrieval_templates
+    ON retrievals.retrieval_template_id = retrieval_templates.id
+WHERE retrieval_id = retrievals.id;
+
+ALTER TABLE retrieval_results ALTER COLUMN cid SET NOT NULL;
+ALTER TABLE retrieval_results ALTER COLUMN provider_address SET NOT NULL;
+ALTER TABLE retrieval_results ALTER COLUMN protocol SET NOT NULL;
+
+-- Remove the foreign key constraint to decouple `retrieval_results` from `retrievals`
+ALTER TABLE retrieval_results DROP CONSTRAINT retrieval_results_retrieval_id_fkey;
+-- Rename the column so that it becomes our independent primary key called `id`
+ALTER TABLE retrieval_results RENAME COLUMN retrieval_id TO id;
+-- Setup autoincrementing for our new PK
+-- See https://dba.stackexchange.com/a/78735/125312
+ALTER TABLE retrieval_results
+   ALTER id ADD GENERATED ALWAYS AS identity;
+-- Adjust the sequence to match the current maximum value
+SELECT setval(pg_get_serial_sequence('retrieval_results', 'id'), max(id))
+FROM retrieval_results;
+

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -54,7 +54,7 @@ export const publish = async ({
 
   // Mark measurements as shared
   await client.query(`
-    UPDATE retrievals
+    UPDATE measurements
     SET published_as = $1
     WHERE id = ANY($2::int[])
   `, [

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -12,26 +12,23 @@ export const publish = async ({
   // Fetch measurements
   const { rows: measurements } = await client.query(`
     SELECT
-      r.id,
-      r.created_at,
-      r.spark_version,
-      r.zinnia_version,
-      rr.finished_at,
-      rr.success,
-      rr.timeout,
-      rr.start_at,
-      rr.status_code,
-      rr.first_byte_at,
-      rr.end_at,
-      rr.byte_length,
-      rr.attestation,
-      rt.cid,
-      rt.provider_address,
-      rt.protocol
-    FROM retrievals r
-    JOIN retrieval_templates rt ON r.retrieval_template_id = rt.id
-    LEFT JOIN retrieval_results rr ON r.id = rr.retrieval_id
-    WHERE r.published_as IS NULL
+      id,
+      spark_version,
+      zinnia_version,
+      finished_at,
+      success,
+      timeout,
+      start_at,
+      status_code,
+      first_byte_at,
+      end_at,
+      byte_length,
+      attestation,
+      cid,
+      provider_address,
+      protocol
+    FROM measurements
+    WHERE published_as IS NULL
     LIMIT $1
   `, [
     maxMeasurements

--- a/test/test.js
+++ b/test/test.js
@@ -390,7 +390,7 @@ describe('Routes', () => {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              success: false,
+              success: true,
               walletAddress,
               startAt: new Date(),
               statusCode: 200,


### PR DESCRIPTION
1. Decouple `retrieval_results` table from `retrieval` to allow us to submit results for retrieval tasks with no linked `retrieval` row.

2. Rename `retrieval_results` to `measurements` to align with MERidian vocabulary.

3. Update `setRetrievalResult` to support the new data schema. This allows existing SPARK checkers to keep reporting measurements.

4. Remove `GET /retrieval/:id` endpoint and replace it with a new endpoint `GET /measurements/:id`. This endpoint is used by integration tests in SPARK checker, we will need to update these tests after this PR lands.

5. Create a new endpoint for submitting retrieval results based on per-round tasks - `POST /measurements`.

I am envisioning the following workflow for the SPARK checker node:
1. Get the current round & the tasks via `GET /rounds/current` - see #80
2. Pick a task, perform the retrieval
3. Call the new API `POST /measurement` to submit the result
4. Rinse and repeat

Connect to https://github.com/filecoin-station/spark/issues/13