### PR TITLE
fix: allow up to 250 concurrent spark-api connections

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,8 +19,8 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 250
+    soft_limit = 200
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
Trying to fix the following problem found in logs:

> Instance 080e126b565608 reached hard limit of 25 concurrent
> connections. This usually indicates your app is not closing
> connections properly or is not closing them fast enough for
> the traffic levels it is handling. Scaling resources, number
> of instances or increasing your hard limit might help.

