### PR TITLE
fix: healthcheck config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -33,7 +33,8 @@ processes = []
     port = 443
 
   [[services.tcp_checks]]
-    grace_period = "1s"
+    path = "/rounds/current"
+    grace_period = "10s"
     interval = "15s"
     restart_limit = 0
     timeout = "2s"


### PR DESCRIPTION
- Increase grace period to 10s, we are fetching FEVM state at startup

- Configure the healthcheck URL as `/rounds/current`. After my recent changes, the root URL `/` is returning 404, and thus failing the check.
