### PR TITLE
fix: set HOST in Fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ processes = []
 
 [env]
   PORT = "8080"
+  HOST = "0.0.0.0"
   SENTRY_ENVIRONMENT = "production"
 
 [experimental]


### PR DESCRIPTION
This is a follow-up for https://github.com/filecoin-station/spark-api/pull/86 - we want to listen on all network interfaces when running in Fly.io