### PR TITLE
perf: add index for `measurements.finished_at`

### DIFF
--- a/migrations/017.do.index-measurements-by-time.sql
+++ b/migrations/017.do.index-measurements-by-time.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY measurements_finished_at ON measurements (finished_at);


### PR DESCRIPTION
Many Grafana charts are filtering and grouping using this column, I hope the index will improve performance of those queries.
