### PR TITLE
fix: don't convert wallet address to ETH format

### DIFF
--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -1,7 +1,6 @@
 /* global File */
 
 import timers from 'node:timers/promises'
-import { ethAddressFromDelegated } from '@glif/filecoin-address'
 
 export const publish = async ({
   client,
@@ -36,12 +35,6 @@ export const publish = async ({
     maxMeasurements
   ])
   logger.log(`Publishing ${measurements.length} measurements`)
-
-  for (const m of measurements) {
-    // Stations are submitting a Filecoin address `f4...`
-    // Smart contracts require an ETH address `0x...`
-    m.wallet_address = convertWalletAddressToEth(m.wallet_address)
-  }
 
   // Share measurements
   const file = new File(
@@ -96,5 +89,3 @@ export const startPublishLoop = async ({
     if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)
   }
 }
-
-export const convertWalletAddressToEth = (filAddress) => ethAddressFromDelegated(filAddress)

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -1,4 +1,4 @@
-import { convertWalletAddressToEth, publish } from '../index.js'
+import { publish } from '../index.js'
 import assert from 'node:assert'
 import { CID } from 'multiformats/cid'
 import pg from 'pg'
@@ -64,16 +64,6 @@ describe('unit', () => {
     assert.strictEqual(web3StoragePutFiles[0].length, 1)
     assert.deepStrictEqual(ieContractMeasurementCIDs, [cid])
   })
-
-  it('converts mainnet wallet address to ETH address', () => {
-    const converted = convertWalletAddressToEth('f410ftgmzttyqi3ti4nxbvixa4byql3o5d4eo3jtc43i')
-    assert.strictEqual(converted, '0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E')
-  })
-
-  it('converts testnet wallet address to ETH address', () => {
-    const converted = convertWalletAddressToEth('t410ftgmzttyqi3ti4nxbvixa4byql3o5d4eo3jtc43i')
-    assert.strictEqual(converted, '0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E')
-  })
 })
 
 describe('integration', () => {
@@ -97,8 +87,7 @@ describe('integration', () => {
       cid: 'bafytest',
       providerAddress: '/dns4/localhost/tcp/8080',
       protocol: 'graphsync',
-      // We are recording wallet address in Filecoin format (f4...)
-      walletAddress: 'f410ftgmzttyqi3ti4nxbvixa4byql3o5d4eo3jtc43i',
+      walletAddress: 't1foobar',
       success: true,
       timeout: false,
       startAt: new Date('2023-09-18T13:33:51.239Z'),
@@ -211,7 +200,7 @@ describe('integration', () => {
     assert.strictEqual(published.cid, measurementRecorded.cid)
     // TODO: test other fields
 
-    // We are publishing the wallet address in ETH format
-    assert.strictEqual(published.wallet_address, '0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E')
+    // We are publishing records with invalid wallet addresses too
+    assert.strictEqual(published.wallet_address, 't1foobar')
   })
 })


### PR DESCRIPTION
Some measurements contain wallet addresses that are not valid (cannot be converted to ETH `0x...` format). As a result, we are no longer publishing any measurements, which means the MERidian contract is no longer advancing the rounds.

This change reverts all address conversions. We should filter out invalid addresses in the evaluation service.

See also:
- #89
- https://github.com/filecoin-station/spark/issues/13
