### PR TITLE
test: remove delay after all tests are done

### DIFF
--- a/spark-publish/lib/telemetry.js
+++ b/spark-publish/lib/telemetry.js
@@ -20,3 +20,5 @@ export const record = (name, fn) => {
   fn(point)
   writeClient.writePoint(point)
 }
+
+export const close = () => writeClient.close()

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -2,8 +2,11 @@ import { publish } from '../index.js'
 import assert from 'node:assert'
 import { CID } from 'multiformats/cid'
 import pg from 'pg'
+import * as telemetry from '../lib/telemetry.js'
 
 const { DATABASE_URL } = process.env
+
+after(telemetry.close)
 
 describe('unit', () => {
   it('publishes', async () => {


### PR DESCRIPTION
Before my change, there was a delay of approx. two seconds after all tests complete but before the Mocha process exits. This delay was caused by the recently added InfluxDB client (commit 35176074).

This commits modifies the test suite to explicitly close the InfluxDB client after all tests finished.
