### PR TITLE
feat: `GET /rounds/meridian/:address/:round`

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -157,19 +157,21 @@ export async function mapCurrentMeridianRoundToSparkRound ({
     )
   }
 
-  await maybeCreateSparkRound(pgClient, sparkRoundNumber)
+  await maybeCreateSparkRound(pgClient, { sparkRoundNumber, meridianContractAddress, meridianRoundIndex })
 
   return sparkRoundNumber
 }
 
-export async function maybeCreateSparkRound (pgClient, sparkRoundNumber) {
+export async function maybeCreateSparkRound (pgClient, { sparkRoundNumber, meridianContractAddress, meridianRoundIndex }) {
   const { rowCount } = await pgClient.query(`
     INSERT INTO spark_rounds
-    (id, created_at)
-    VALUES ($1, now())
+    (id, created_at, meridian_address, meridian_round)
+    VALUES ($1, now(), $2, $3)
     ON CONFLICT DO NOTHING
   `, [
-    sparkRoundNumber
+    sparkRoundNumber,
+    meridianContractAddress,
+    meridianRoundIndex
   ])
 
   if (rowCount) {

--- a/migrations/020.do.round-to-ie-mapping.sql
+++ b/migrations/020.do.round-to-ie-mapping.sql
@@ -1,0 +1,2 @@
+ALTER TABLE spark_rounds ADD COLUMN meridian_address TEXT NOT NULL DEFAULT '0x00';
+ALTER TABLE spark_rounds ADD COLUMN meridian_round BIGINT NOT NULL DEFAULT 0;

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -36,6 +36,8 @@ describe('Round Tracker', () => {
       let sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
       assertApproximately(sparkRounds[0].created_at, new Date(), 30_000)
+      assert.strictEqual(sparkRounds[0].meridian_address, '0x1a')
+      assert.strictEqual(sparkRounds[0].meridian_round, '120')
 
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',


### PR DESCRIPTION
Introduce a new API for obtaining SPARK round details for the given Meridian contract address + IE round.

Links:
- https://github.com/filecoin-station/spark/issues/13