### PR TITLE
feat: `GET /round/meridian/:address/:round`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const handler = async (req, res, client, getCurrentRound) => {
     await createMeasurement(req, res, client, getCurrentRound)
   } else if (segs[0] === 'measurements' && req.method === 'GET') {
     await getMeasurement(req, res, client, Number(segs[1]))
+  } else if (segs[0] === 'rounds' && segs[1] === 'meridian' && req.method === 'GET') {
+    await getMeridianRoundDetails(req, res, client, segs[2], segs[3])
   } else if (segs[0] === 'rounds' && req.method === 'GET') {
     await getRoundDetails(req, res, client, getCurrentRound, segs[1])
   } else {
@@ -237,21 +239,64 @@ const getRoundDetails = async (req, res, client, getCurrentRound, roundParam) =>
     res.setHeader('cache-control', 'no-store')
   }
 
+  await replyWithDetailsForRoundNumber(res, client, roundNumber)
+}
+
+const replyWithDetailsForRoundNumber = async (res, client, roundNumber) => {
   const { rows: [round] } = await client.query('SELECT * FROM spark_rounds WHERE id = $1', [roundNumber])
   if (!round) {
     return notFound(res)
   }
 
-  const { rows: tasks } = await client.query('SELECT * FROM retrieval_tasks WHERE round_id = $1', [roundNumber])
+  const { rows: tasks } = await client.query('SELECT * FROM retrieval_tasks WHERE round_id = $1', [round.id])
 
   json(res, {
-    roundId: roundNumber.toString(),
+    roundId: round.id.toString(),
     retrievalTasks: tasks.map(t => ({
       cid: t.cid,
       providerAddress: t.provider_address,
       protocol: t.protocol
     }))
   })
+}
+
+const getMeridianRoundDetails = async (_req, res, client, meridianAddress, meridianRound) => {
+  meridianRound = BigInt(meridianRound)
+  const { rows } = await client.query(`
+    SELECT
+      first_spark_round_number - spark_round_offset as first,
+      last_spark_round_number - spark_round_offset as last,
+      spark_round_offset as offset
+    FROM meridian_contract_versions
+    WHERE contract_address = $1
+  `, [
+    meridianAddress
+  ])
+  if (!rows.length) {
+    console.error('Unknown Meridian contract address: %s', meridianAddress)
+    return notFound(res)
+  }
+  const first = BigInt(rows[0].first)
+  const last = BigInt(rows[0].last)
+  const offset = BigInt(rows[0].offset)
+
+  if (meridianRound < first || meridianRound > last) {
+    console.error('Meridian contract %s round %s is out of bounds [%s, %s]',
+      meridianAddress,
+      meridianRound,
+      first,
+      last
+    )
+    return notFound(res)
+  }
+
+  const roundNumber = meridianRound + offset
+  console.log('Mapped meridian contract %s round %s to SPARK round %s',
+    meridianAddress,
+    meridianRound,
+    roundNumber
+  )
+  await replyWithDetailsForRoundNumber(res, client, roundNumber)
 }
 
 const parseRoundNumberOrCurrent = async (getCurrentRound, roundParam) => {

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -141,8 +141,8 @@ export async function mapCurrentMeridianRoundToSparkRound ({
     // this edge case by telling Postgres to ignore conflicts (`ON CONFLICT DO NOTHING)`
     await pgClient.query(`
       INSERT INTO meridian_contract_versions
-      (contract_address, spark_round_offset, last_spark_round_number)
-      VALUES ($1, $2, $3)
+      (contract_address, spark_round_offset, last_spark_round_number, first_spark_round_number)
+      VALUES ($1, $2, $3, $3)
     `, [
       meridianContractAddress,
       sparkRoundOffset,

--- a/migrations/020.do.first-spark-round-for-meridian.sql
+++ b/migrations/020.do.first-spark-round-for-meridian.sql
@@ -1,0 +1,23 @@
+ALTER TABLE meridian_contract_versions ADD COLUMN first_spark_round_number BIGINT;
+
+-- Manually set first_spark_round_number for known IE versions
+-- as observed in our production deployment on Fly.io
+UPDATE meridian_contract_versions
+SET first_spark_round_number = 1414
+WHERE
+  contract_address = '0x3113b83ccec38a18df936f31297de490485d7b2e'
+  AND spark_round_offset = 1414;
+
+UPDATE meridian_contract_versions
+SET first_spark_round_number = 986
+WHERE
+  contract_address = '0x381b50e8062757c404dec2bfae4da1b495341af9'
+  AND spark_round_offset = 985;
+
+-- For legacy contract versions, set first_spark_round_number to some meaningful value
+-- that will not break lookups. We don't expect to look up these old rounds anyways.
+UPDATE meridian_contract_versions
+SET first_spark_round_number = last_spark_round_number
+WHERE first_spark_round_number IS NULL;
+
+ALTER TABLE meridian_contract_versions ALTER COLUMN first_spark_round_number SET NOT NULL;


### PR DESCRIPTION
Introduce a new API for obtaining SPARK round details for the given Meridian contract address + IE round.

This is a reworked version of #101 that is much lighter on DB storage & migration.

Links:
- https://github.com/filecoin-station/spark/issues/13
