### PR TITLE
feat: record "inet_group" in measurements

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
   validate(measurement, 'byteLength', { type: 'number', required: false })
   validate(measurement, 'attestation', { type: 'string', required: false })
 
-  const inetGroup = mapRequestToInetGroup(req)
+  const inetGroup = await mapRequestToInetGroup(client, req)
   console.log('inet group: %o', inetGroup)
 
   const { rows } = await client.query(`

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -1,0 +1,24 @@
+// See https://stackoverflow.com/a/36760050/69868
+const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/
+
+export const mapRequestToInetGroup = (/** @type {import('node:http').IncomingMessage} */ req) => {
+  let addr = req.socket.remoteAddress
+
+  const flyClientAddr = req.headers['fly-client-ip']
+  if (flyClientAddr) addr = flyClientAddr
+
+  if (addr?.startsWith('::ffff:')) {
+    // Some operating systems are wrapping the IPv4 address into IPv6
+    // https://www.apnic.net/get-ip/faqs/what-is-an-ip-address/ipv6-address-types/
+    addr = addr.slice(7)
+  }
+
+  if (!IPV4_REGEX.test(addr)) {
+    return undefined
+  }
+
+  // Hide the last byte of the IPv4 address, change it to "0"
+  addr = addr.slice(0, addr.lastIndexOf('.')) + '.0'
+
+  return addr
+}

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -1,11 +1,108 @@
+import { base64url } from 'multiformats/bases/base64'
+
 // See https://stackoverflow.com/a/36760050/69868
 const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/
 
-export const mapRequestToInetGroup = (/** @type {import('node:http').IncomingMessage} */ req) => {
+/**
+ * @param {import('pg').Client} client
+ * @param {import('node:http').IncomingMessage} req
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export const mapRequestToInetGroup = async (pgClient, req, now = new Date()) => {
+  const subnet = mapRequestToSubnet(req)
+  const group = await mapSubnetToInetGroup(pgClient, subnet, now)
+  return group
+}
+
+/**
+ * @param {import('pg').Client} client
+ * @param {string} subnet
+ * @param {Date} [now]
+ * @returns {Promise<string>}
+ */
+export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) => {
+  const { rows: [found] } = await pgClient.query(
+    'SELECT id FROM inet_groups WHERE subnet = $1',
+    [subnet]
+  )
+  if (found) return found.id
+
+  let remainingRetries = 5
+  for (;; remainingRetries--) {
+    const group = generateUniqueGroupId(now)
+    try {
+      // There is a race condition: between the time we looked up the existing group
+      // and the time we execute this query, a handler for a different request from
+      // the same subnet may have already defined the group for this subnet.
+      // Solution: when insert fails with a conflict in the group id, use that existing group
+      // instead of the value we generated ourselves.
+      //
+      // ON CONFLICT DO UPDATE is needed to tell PG to return the existing id on conflict
+      // ON CONFLICT DO NOTHING would not return the existing id on conflict
+      const { rows: [created] } = await pgClient.query(`
+        INSERT INTO inet_groups (id, subnet, created_at)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (subnet) DO UPDATE SET id = inet_groups.id
+        RETURNING id
+       `, [
+        group,
+        subnet,
+        now.toISOString()
+      ])
+      return created.id
+    } catch (err) {
+      if (err.code === 23505 && err.constraint === 'inet_groups_pkey') {
+        // Retry with a different random id
+        if (remainingRetries > 0) continue
+        // Fail if we exhausted allowed attempts
+        throw new Error('Failed to generate a unique group id')
+      }
+      throw err
+    }
+  }
+}
+
+/**
+ * @param {Date} [now]
+ * @returns {Promise<string>}
+ */
+const generateUniqueGroupId = (now) => {
+  const data = new ArrayBuffer(8)
+
+  const prefix = new Uint8Array(data, 0, 2)
+
+  // To reduce the likelihood of generating the same group values for different subnets,
+  // and also to make it easier to diagnose invalid use of groups (e.g. after they should
+  // have been expired), let's prefix the group with a single byte derived from the number
+  // of hours elapsed since the Unix epoch.
+  // 251 is the largest prime number that fits into a single byte.
+  prefix[0] = now.getTime() / 3600_000 % 251
+
+  // We are running this code in more than one process. To reduce possible clashes, let's
+  // add another byte derived from the millisecond time.
+  prefix[1] = now.getTime() % 251
+
+  // Finally, add six random bytes
+  globalThis.crypto.getRandomValues(new Uint8Array(data, 2, 6))
+
+  return base64url.encode(new Uint8Array(data))
+}
+
+/**
+ * @param {import('node:http').IncomingMessage} req
+ * @returns {Promise<string>}
+ */
+export const mapRequestToSubnet = (req) => {
   let addr = req.socket.remoteAddress
 
   const flyClientAddr = req.headers['fly-client-ip']
   if (flyClientAddr) addr = flyClientAddr
+
+  // TODO accept the value in this header only when the request is coming from Cloudflare
+  // See https://www.cloudflare.com/en-gb/ips/
+  const cfAddr = req.headers['cf-connecting-ip']
+  if (cfAddr) addr = cfAddr
 
   if (addr?.startsWith('::ffff:')) {
     // Some operating systems are wrapping the IPv4 address into IPv6
@@ -13,12 +110,13 @@ export const mapRequestToInetGroup = (/** @type {import('node:http').IncomingMes
     addr = addr.slice(7)
   }
 
-  if (!IPV4_REGEX.test(addr)) {
+  if (!addr || !IPV4_REGEX.test(addr)) {
     return undefined
   }
 
   // Hide the last byte of the IPv4 address, change it to "0"
-  addr = addr.slice(0, addr.lastIndexOf('.')) + '.0'
+  // Also encode the subnet size
+  addr = addr.slice(0, addr.lastIndexOf('.')) + '.0/24'
 
   return addr
 }

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -64,7 +64,7 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
 }
 
 /**
- * @param {Date} [now]
+ * @param {Date} now
  * @returns {Promise<string>}
  */
 const generateUniqueGroupId = (now) => {

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -6,23 +6,21 @@ const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|
 /**
  * @param {import('pg').Client} client
  * @param {import('node:http').IncomingMessage} req
- * @param {Date} [now]
  * @returns {string}
  */
-export const mapRequestToInetGroup = async (pgClient, req, now = new Date()) => {
+export const mapRequestToInetGroup = async (pgClient, req) => {
   const subnet = mapRequestToSubnet(req)
   if (!subnet) return 'ipv6'
-  const group = await mapSubnetToInetGroup(pgClient, subnet, now)
+  const group = await mapSubnetToInetGroup(pgClient, subnet)
   return group
 }
 
 /**
  * @param {import('pg').Client} client
  * @param {string} subnet
- * @param {Date} [now]
  * @returns {Promise<string>}
  */
-export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) => {
+export const mapSubnetToInetGroup = async (pgClient, subnet) => {
   const { rows: [found] } = await pgClient.query(
     'SELECT id FROM inet_groups WHERE subnet = $1',
     [subnet]
@@ -30,7 +28,7 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
   if (found) return found.id
 
   for (let remainingRetries = 5; remainingRetries > 0; remainingRetries--) {
-    const group = generateUniqueGroupId(now)
+    const group = generateUniqueGroupId()
     try {
       // There is a race condition: between the time we looked up the existing group
       // and the time we execute this query, a handler for a different request from
@@ -41,14 +39,13 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
       // ON CONFLICT DO UPDATE is needed to tell PG to return the existing id on conflict
       // ON CONFLICT DO NOTHING would not return the existing id on conflict
       const { rows: [created] } = await pgClient.query(`
-        INSERT INTO inet_groups (id, subnet, created_at)
-        VALUES ($1, $2, $3)
+        INSERT INTO inet_groups (id, subnet)
+        VALUES ($1, $2)
         ON CONFLICT (subnet) DO UPDATE SET id = inet_groups.id
         RETURNING id
        `, [
         group,
-        subnet,
-        now
+        subnet
       ])
       return created.id
     } catch (err) {
@@ -64,29 +61,12 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
 }
 
 /**
- * @param {Date} now
- * @returns {Promise<string>}
+ * @returns {string}
  */
-const generateUniqueGroupId = (now) => {
-  const data = new ArrayBuffer(8)
-
-  const prefix = new Uint8Array(data, 0, 2)
-
-  // To reduce the likelihood of generating the same group values for different subnets,
-  // and also to make it easier to diagnose invalid use of groups (e.g. after they should
-  // have been expired), let's prefix the group with a single byte derived from the number
-  // of hours elapsed since the Unix epoch.
-  // 251 is the largest prime number that fits into a single byte.
-  prefix[0] = now.getTime() / 3600_000 % 251
-
-  // We are running this code in more than one process. To reduce possible clashes, let's
-  // add another byte derived from the millisecond time.
-  prefix[1] = now.getTime() % 251
-
-  // Finally, add six random bytes
-  globalThis.crypto.getRandomValues(new Uint8Array(data, 2, 6))
-
-  return base64url.encode(new Uint8Array(data))
+const generateUniqueGroupId = () => {
+  const data = new Uint8Array(8)
+  globalThis.crypto.getRandomValues(data)
+  return base64url.encode(data)
 }
 
 /**

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -29,8 +29,7 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
   )
   if (found) return found.id
 
-  let remainingRetries = 5
-  for (;; remainingRetries--) {
+  for (let remainingRetries = 5; remainingRetries > 0; remainingRetries--) {
     const group = generateUniqueGroupId(now)
     try {
       // There is a race condition: between the time we looked up the existing group
@@ -55,13 +54,13 @@ export const mapSubnetToInetGroup = async (pgClient, subnet, now = new Date()) =
     } catch (err) {
       if (err.code === 23505 && err.constraint === 'inet_groups_pkey') {
         // Retry with a different random id
-        if (remainingRetries > 0) continue
-        // Fail if we exhausted allowed attempts
-        throw new Error('Failed to generate a unique group id')
+        continue
       }
       throw err
     }
   }
+  // We have exhausted allowed attempts
+  throw new Error('Failed to generate a unique group id')
 }
 
 /**

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -11,6 +11,7 @@ const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|
  */
 export const mapRequestToInetGroup = async (pgClient, req, now = new Date()) => {
   const subnet = mapRequestToSubnet(req)
+  if (!subnet) return 'ipv6'
   const group = await mapSubnetToInetGroup(pgClient, subnet, now)
   return group
 }
@@ -91,7 +92,7 @@ const generateUniqueGroupId = (now) => {
 
 /**
  * @param {import('node:http').IncomingMessage} req
- * @returns {Promise<string>}
+ * @returns {string | undefined}
  */
 export const mapRequestToSubnet = (req) => {
   let addr = req.socket.remoteAddress

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -80,6 +80,7 @@ export const mapRequestToSubnet = (req) => {
   if (flyClientAddr) addr = flyClientAddr
 
   // TODO accept the value in this header only when the request is coming from Cloudflare
+  // Check that `req.socket.remoteAddress` matches one of the well-known Cloudflare's addresses
   // See https://www.cloudflare.com/en-gb/ips/
   const cfAddr = req.headers['cf-connecting-ip']
   if (cfAddr) addr = cfAddr

--- a/lib/inet-grouping.js
+++ b/lib/inet-grouping.js
@@ -104,13 +104,15 @@ export const mapRequestToSubnet = (req) => {
   const cfAddr = req.headers['cf-connecting-ip']
   if (cfAddr) addr = cfAddr
 
-  if (addr?.startsWith('::ffff:')) {
+  if (!addr) return undefined
+
+  if (addr.startsWith('::ffff:')) {
     // Some operating systems are wrapping the IPv4 address into IPv6
     // https://www.apnic.net/get-ip/faqs/what-is-an-ip-address/ipv6-address-types/
     addr = addr.slice(7)
   }
 
-  if (!addr || !IPV4_REGEX.test(addr)) {
+  if (!IPV4_REGEX.test(addr)) {
     return undefined
   }
 

--- a/migrations/021.do.inet-group-for-measurements.sql
+++ b/migrations/021.do.inet-group-for-measurements.sql
@@ -1,4 +1,12 @@
 -- Store the value as text instead of a network datatype.
 -- (See https://www.postgresql.org/docs/current/datatype-net-types.html)
--- This allow us to easily change the group format in the future, e.g. to obfuscate the real address
+-- For privacy reasons, we are hiding the real IP addresses and storing random identifiers instead
 ALTER TABLE measurements ADD COLUMN inet_group TEXT;
+
+CREATE TABLE inet_groups (
+  id TEXT NOT NULL PRIMARY KEY,
+  subnet CIDR NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX inet_groups_created_at ON inet_groups (created_at);

--- a/migrations/021.do.inet-group-for-measurements.sql
+++ b/migrations/021.do.inet-group-for-measurements.sql
@@ -1,0 +1,4 @@
+-- Store the value as text instead of a network datatype.
+-- (See https://www.postgresql.org/docs/current/datatype-net-types.html)
+-- This allow us to easily change the group format in the future, e.g. to obfuscate the real address
+ALTER TABLE measurements ADD COLUMN inet_group TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "raw-body": "^2.5.2"
       },
       "devDependencies": {
+        "light-my-request": "^5.11.0",
         "mocha": "^10.2.0",
         "standard": "^17.1.0",
         "varint": "^6.0.0"
@@ -2993,6 +2994,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.11.0.tgz",
+      "integrity": "sha512-qkFCeloXCOMpmEdZ/MV91P8AT4fjwFXWaAFz3lUeStM8RcoM1ks4J/F8r1b3r6y/H4u3ACEJ1T+Gv5bopj7oDA==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
@@ -3725,6 +3737,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+      "dev": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3979,6 +3997,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ethers": "^5.7.2",
         "http-assert": "^1.5.0",
         "http-responders": "^2.0.2",
+        "multiformats": "^12.1.2",
         "pg": "^8.11.3",
         "postgrator": "^7.2.0",
         "raw-body": "^2.5.2"
@@ -3244,6 +3245,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/multiformats": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.2.tgz",
+      "integrity": "sha512-6mRIsrZXyw5xNPO31IGBMmxgDXBSgCGDsBAtazkZ02ip4hMwZNrQvfxXZtytRoBSWuzSq5f9VmMnXj76fIz5FQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "standard && mocha"
   },
   "devDependencies": {
+    "light-my-request": "^5.11.0",
     "mocha": "^10.2.0",
     "standard": "^17.1.0",
     "varint": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ethers": "^5.7.2",
     "http-assert": "^1.5.0",
     "http-responders": "^2.0.2",
+    "multiformats": "^12.1.2",
     "pg": "^8.11.3",
     "postgrator": "^7.2.0",
     "raw-body": "^2.5.2"

--- a/test/inet-grouping.test.js
+++ b/test/inet-grouping.test.js
@@ -1,20 +1,55 @@
 import assert from 'node:assert'
-import { mapRequestToInetGroup } from '../lib/inet-grouping.js'
+import pg from 'pg'
+import { mapRequestToInetGroup, mapRequestToSubnet, mapSubnetToInetGroup } from '../lib/inet-grouping.js'
 import { Request as FakeRequest } from 'light-my-request/lib/request.js'
+import { migrate } from '../lib/migrate.js'
+
+const { DATABASE_URL } = process.env
+
+let pgClient
+
+before(async () => {
+  pgClient = new pg.Client({ connectionString: DATABASE_URL })
+  await pgClient.connect()
+  await migrate(pgClient)
+})
+
+after(async () => {
+  await pgClient.end()
+})
 
 describe('mapRequestToInetGroup', () => {
+  beforeEach(async () => {
+    await pgClient.query('DELETE FROM inet_groups')
+  })
+
+  it('returns a randomly assigned group based on IPv4 /24 subnet', async () => {
+    const first = await mapRequestToInetGroup(pgClient, createRequestFromAddress('10.20.30.1'))
+    assert.match(first, /^.{12}$/)
+
+    // Different address in the same /24 subnet
+    const second = await mapRequestToInetGroup(pgClient, createRequestFromAddress('10.20.30.2'))
+    assert.strictEqual(second, first)
+
+    // Different /24 subnet
+    const different = await mapRequestToInetGroup(pgClient, createRequestFromAddress('10.20.99.1'))
+    assert.notStrictEqual(different, first)
+  })
+})
+
+describe('mapRequestToSubnet', () => {
   it('maps IPv4 address to /24 subnet', () => {
-    const group = mapRequestToInetGroup(createRequestFromAddress('10.20.30.40'))
-    assert.strictEqual(group, '10.20.30.0')
+    const group = mapRequestToSubnet(createRequestFromAddress('10.20.30.40'))
+    assert.strictEqual(group, '10.20.30.0/24')
   })
 
   it('maps IPv4-inside-IPv6 to IPv4 /24 subnet', () => {
-    const group = mapRequestToInetGroup(createRequestFromAddress('::ffff:127.0.0.1'))
-    assert.strictEqual(group, '127.0.0.0')
+    const group = mapRequestToSubnet(createRequestFromAddress('::ffff:127.0.0.1'))
+    assert.strictEqual(group, '127.0.0.0/24')
   })
 
   it('rejects IPv6 addresses', () => {
-    const group = mapRequestToInetGroup(createRequestFromAddress('bf27:c63a:689a:da7c:8150:6e23:1045:045d'))
+    const group = mapRequestToSubnet(createRequestFromAddress('bf27:c63a:689a:da7c:8150:6e23:1045:045d'))
     assert.strictEqual(group, undefined)
   })
 
@@ -22,16 +57,61 @@ describe('mapRequestToInetGroup', () => {
     const req = createRequestFromAddress('10.20.30.40', {
       'Fly-Client-IP': '1.2.3.4'
     })
-    const group = mapRequestToInetGroup(req)
-    assert.strictEqual(group, '1.2.3.0')
+    const group = mapRequestToSubnet(req)
+    assert.strictEqual(group, '1.2.3.0/24')
   })
 
   it('parses `fly-client-ip` request header', () => {
     const req = createRequestFromAddress('10.20.30.40', {
       'fly-client-ip': '1.2.3.4'
     })
-    const group = mapRequestToInetGroup(req)
-    assert.strictEqual(group, '1.2.3.0')
+    const group = mapRequestToSubnet(req)
+    assert.strictEqual(group, '1.2.3.0/24')
+  })
+
+  it('parses `CF-Connecting-IP', () => {
+    const req = createRequestFromAddress('10.20.30.40', {
+      'CF-Connecting-IP': '50.60.70.80'
+    })
+    const group = mapRequestToSubnet(req)
+    assert.strictEqual(group, '50.60.70.0/24')
+  })
+})
+
+describe('mapSubnetToInetGroup', () => {
+  beforeEach(async () => {
+    await pgClient.query('DELETE FROM inet_groups')
+  })
+
+  it('maps a newly seen subnet', async () => {
+    const now = new Date('2023-10-24T10:20:30.456Z')
+    const group = await mapSubnetToInetGroup(pgClient, '127.0.0.0/24', now)
+    assert.match(group, /^uTa.{9}$/)
+
+    const { rows } = await pgClient.query('SELECT * FROM inet_groups')
+    assert.deepStrictEqual(rows, [
+      {
+        id: group,
+        subnet: '127.0.0.0/24',
+        created_at: now
+      }
+    ])
+  })
+
+  it('maps an already seen subnet', async () => {
+    const now = new Date('2023-10-24T10:20:30.456Z')
+    const first = await mapSubnetToInetGroup(pgClient, '127.0.0.0/24', now)
+    const second = await mapSubnetToInetGroup(pgClient, '127.0.0.0/24', new Date())
+    assert.strictEqual(first, second)
+
+    const { rows } = await pgClient.query('SELECT * FROM inet_groups')
+    assert.deepStrictEqual(rows, [
+      {
+        id: first,
+        subnet: '127.0.0.0/24',
+        created_at: now
+      }
+    ])
   })
 })
 

--- a/test/inet-grouping.test.js
+++ b/test/inet-grouping.test.js
@@ -35,6 +35,11 @@ describe('mapRequestToInetGroup', () => {
     const different = await mapRequestToInetGroup(pgClient, createRequestFromAddress('10.20.99.1'))
     assert.notStrictEqual(different, first)
   })
+
+  it('maps all IPv6 address to the same inet_group', async () => {
+    const group = await mapRequestToInetGroup(pgClient, createRequestFromAddress('bf27:c63a:689a:da7c:8150:6e23:1045:045d'))
+    assert.strictEqual(group, 'ipv6')
+  })
 })
 
 describe('mapRequestToSubnet', () => {

--- a/test/inet-grouping.test.js
+++ b/test/inet-grouping.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert'
+import { mapRequestToInetGroup } from '../lib/inet-grouping.js'
+import { Request as FakeRequest } from 'light-my-request/lib/request.js'
+
+describe('mapRequestToInetGroup', () => {
+  it('maps IPv4 address to /24 subnet', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('10.20.30.40'))
+    assert.strictEqual(group, '10.20.30.0')
+  })
+
+  it('maps IPv4-inside-IPv6 to IPv4 /24 subnet', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('::ffff:127.0.0.1'))
+    assert.strictEqual(group, '127.0.0.0')
+  })
+
+  it('rejects IPv6 addresses', () => {
+    const group = mapRequestToInetGroup(createRequestFromAddress('bf27:c63a:689a:da7c:8150:6e23:1045:045d'))
+    assert.strictEqual(group, undefined)
+  })
+
+  it('parses `Fly-Client-IP` request header', () => {
+    const req = createRequestFromAddress('10.20.30.40', {
+      'Fly-Client-IP': '1.2.3.4'
+    })
+    const group = mapRequestToInetGroup(req)
+    assert.strictEqual(group, '1.2.3.0')
+  })
+
+  it('parses `fly-client-ip` request header', () => {
+    const req = createRequestFromAddress('10.20.30.40', {
+      'fly-client-ip': '1.2.3.4'
+    })
+    const group = mapRequestToInetGroup(req)
+    assert.strictEqual(group, '1.2.3.0')
+  })
+})
+
+const createRequestFromAddress = (remoteAddress, headers) => {
+  return new FakeRequest({
+    method: 'GET',
+    url: '/',
+    remoteAddress,
+    headers
+  })
+}

--- a/test/test.js
+++ b/test/test.js
@@ -468,7 +468,7 @@ describe('Routes', () => {
       assert.strictEqual(measurementRow.zinnia_version, '2.3.4')
       assert.strictEqual(measurementRow.completed_at_round, currentSparkRoundNumber.toString())
       assert.strictEqual(measurementRow.published_as, null)
-      assert.strictEqual(measurementRow.inet_group, '127.0.0.0')
+      assert.match(measurementRow.inet_group, /^.{12}$/)
     })
 
     it('allows older format with walletAddress', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -467,6 +467,7 @@ describe('Routes', () => {
       assert.strictEqual(measurementRow.zinnia_version, '2.3.4')
       assert.strictEqual(measurementRow.completed_at_round, currentSparkRoundNumber.toString())
       assert.strictEqual(measurementRow.published_as, null)
+      assert.strictEqual(measurementRow.inet_group, '127.0.0.0')
     })
 
     it('allows older format with walletAddress', async () => {


### PR DESCRIPTION
Convert the IP address of the SPARK checker node submitting a measurement into an IPv4 /24 subnet (e.g. 127.0.0.0).

Recognize `Fly-Client-IP` and `CF-Connecting-IP` request headers to obtain the real client address as observed by Fly's/CloudFlare's load balancer.

Requests coming via IPv6 (or other transports that IP) get assigned a hard-coded group `ipv6`.

Links:
- https://github.com/filecoin-station/spark/issues/29