### PR TITLE
feat: add an API to inspect request's IP address

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ const handler = async (req, res, client, getCurrentRound, domain) => {
     await getMeridianRoundDetails(req, res, client, segs[2], segs[3])
   } else if (segs[0] === 'rounds' && req.method === 'GET') {
     await getRoundDetails(req, res, client, getCurrentRound, segs[1])
+  } else if (segs[0] === 'inspect-request' && req.method === 'GET') {
+    await inspectRequest(req, res)
   } else {
     notFound(res)
   }
@@ -341,6 +343,16 @@ const redirect = (res, location) => {
   res.statusCode = 301
   res.setHeader('location', location)
   res.end()
+}
+
+export const inspectRequest = async (req, res) => {
+  await json(res, {
+    remoteAddress: req.socket.remoteAddress,
+    flyClientAddr: req.headers['fly-client-ip'],
+    cloudfareAddr: req.headers['cf-connecting-ip'],
+    forwardedFor: req.headers['x-forwarded-for'],
+    headers: req.headersDistinct
+  })
 }
 
 export const createHandler = async ({


### PR DESCRIPTION
The new endpoint tells the caller what IP addresses we see, as coming from
the IP stack, Fly.io and CloudFare. This is useful to verify our understanding
of how all reverse proxies interact together.

Links:
- https://github.com/filecoin-station/spark-api/pull/104
- https://github.com/filecoin-station/spark/issues/29
- https://developers.cloudflare.com/fundamentals/reference/http-request-headers/
- https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips/
