### PR TITLE
chore: upgrade Dockerfiles to Node.js 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye as builder
 
-ARG NODE_VERSION=16.20.1
+ARG NODE_VERSION=20.8.1
 
 RUN apt-get update; apt install -y curl python-is-python3 pkg-config build-essential
 RUN curl https://get.volta.sh | bash

--- a/spark-publish/Dockerfile
+++ b/spark-publish/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.3.1
+ARG NODE_VERSION=20.8.1
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Node.js"


### PR DESCRIPTION
- https://github.com/filecoin-station/spark-api/pull/104 required global `crypto` object which is not available in Node.js 18
- Node.js 20 has recently entered LTS