### PR TITLE
fix: rework spark-api Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,43 @@
-FROM debian:bullseye as builder
+# syntax = docker/dockerfile:1
 
+# Adjust NODE_VERSION as desired
 ARG NODE_VERSION=20.8.1
-
-RUN apt-get update; apt install -y curl python-is-python3 pkg-config build-essential
-RUN curl https://get.volta.sh | bash
-ENV VOLTA_HOME /root/.volta
-ENV PATH /root/.volta/bin:$PATH
-RUN volta install node@${NODE_VERSION}
-
-#######################################################################
-
-RUN mkdir /app
-WORKDIR /app
-
-# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
-# to install all modules: "npm install --production=false".
-# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
-
-ENV NODE_ENV production
-
-COPY . .
-
-RUN npm install
-FROM debian:bullseye
+FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="nodejs"
 
-COPY --from=builder /root/.volta /root/.volta
-COPY --from=builder /app /app
-
+# Node.js app lives here
 WORKDIR /app
+
+# Set production environment
 ENV NODE_ENV production
-ENV PATH /root/.volta/bin:$PATH
+ENV SENTRY_ENVIRONMENT production
 ENV DOMAIN api.filspark.com
 
+#######################################################################
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build node modules
+RUN apt-get update -qq && \
+  apt-get install -y build-essential pkg-config python-is-python3
+
+# Install node modules
+# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
+# to install all modules: "npm install --production=false".
+# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
+COPY --link package-lock.json package.json ./
+RUN npm ci
+
+# Copy application code
+COPY --link . .
+
+#######################################################################
+# Final stage for app image
+FROM base
+
+# Copy built application
+COPY --from=build /app /app
+
+# Start the server by default, this can be overwritten at runtime
 CMD [ "npm", "run", "start" ]

--- a/spark-publish/Dockerfile
+++ b/spark-publish/Dockerfile
@@ -4,16 +4,17 @@
 ARG NODE_VERSION=20.8.1
 FROM node:${NODE_VERSION}-slim as base
 
-LABEL fly_launch_runtime="Node.js"
+LABEL fly_launch_runtime="nodejs"
 
 # Node.js app lives here
 WORKDIR /app
 
 # Set production environment
-ENV NODE_ENV="production"
-ENV SENTRY_ENVIRONMENT="production"
-ENV MAX_MEASUREMENTS_PER_ROUND=2000
+ENV NODE_ENV production
+ENV SENTRY_ENVIRONMENT production
+ENV MAX_MEASUREMENTS_PER_ROUND 2000
 
+#######################################################################
 # Throw-away build stage to reduce size of final image
 FROM base as build
 
@@ -22,13 +23,16 @@ RUN apt-get update -qq && \
     apt-get install -y build-essential pkg-config python-is-python3
 
 # Install node modules
+# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
+# to install all modules: "npm install --production=false".
+# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
 COPY --link package-lock.json package.json ./
 RUN npm ci
 
 # Copy application code
 COPY --link . .
 
-
+#######################################################################
 # Final stage for app image
 FROM base
 


### PR DESCRIPTION
Remove dependency on Volta, use Node.js official Docker image instead.

Unify the content of spark-api and spark-publish Dockerfiles
so that we consistently use the same setup everywhere.
