### PR TITLE
fix: send 4xx error for removed endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const handler = async (req, res, client, getCurrentRound, domain) => {
     // TODO: Deprecate once clients have been updated
     await setRetrievalResult(req, res, client, Number(segs[1]), getCurrentRound)
   } else if (segs[0] === 'retrievals' && req.method === 'GET') {
-    assert.fail(501, 'This API endpoint is no longer supported.')
+    assert.fail(410, 'This API endpoint is no longer supported.')
   } else if (segs[0] === 'measurements' && req.method === 'POST') {
     await createMeasurement(req, res, client, getCurrentRound)
   } else if (segs[0] === 'measurements' && req.method === 'GET') {

--- a/test/test.js
+++ b/test/test.js
@@ -408,7 +408,7 @@ describe('Routes', () => {
   describe('GET /retrievals/:id', () => {
     it('returns error', async () => {
       const res = await fetch(`${spark}/retrievals/0`)
-      await assertResponseStatus(res, 501 /* Not Implemented */)
+      await assertResponseStatus(res, 410 /* Gone */)
     })
   })
   describe('POST /measurements', () => {


### PR DESCRIPTION
Change the response error code from 5xx to 4xx so that we don't report the error to Sentry.

> The HyperText Transfer Protocol (HTTP) 410 Gone client error response code indicates that access to the target resource is no longer available at the origin server and that this condition is likely to be permanent.

Sentry event: https://protocol-labs-ip.sentry.io/issues/4570961976/events/d32bf8aaa99d4475b3de596e8a97317f/

