### PR TITLE
db: add timezone to `measurements.finished_at`

### DIFF
--- a/migrations/027.do.measurements-finished-at-with-timezone.sql
+++ b/migrations/027.do.measurements-finished-at-with-timezone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE measurements ALTER COLUMN finished_at SET DATA TYPE timestamptz;


### PR DESCRIPTION
Make the data type consistent with other columns storing date-time values.

Note: the migration will take a long time because we have ~12M measurements.
I will run it manually before landing this PR. I verified this particular
migration can be applied multiple times - subsequent runs are a quick no-op.
