### PR TITLE
feat: report load of spark-publish

### DIFF
--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -10,6 +10,11 @@ export const publish = async ({
   maxMeasurements = 1000,
   logger = console
 }) => {
+  // Fetch the count of all unpublished measurements - we need this for monitoring
+  const totalCount = (await client.query(
+    'SELECT COUNT(*) FROM measurements WHERE published_as IS NULL'
+  )).rows[0].count
+
   // Fetch measurements
   const { rows: measurements } = await client.query(`
     SELECT
@@ -78,6 +83,7 @@ export const publish = async ({
   record('publish', point => {
     point.intField('round_index', roundIndex)
     point.intField('measurements', measurements.length)
+    point.floatField('load', measurements.length / totalCount)
     point.intField(
       'upload_measurements_duration_ms',
       uploadMeasurementsDuration

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -14,7 +14,11 @@ describe('unit', () => {
 
     const clientQueryParams = []
     const client = {
-      async query (_, params) {
+      async query (statement, params) {
+        if (statement.includes('SELECT COUNT(*) FROM measurements')) {
+          return { rows: [{ count: 10 }] }
+        }
+
         clientQueryParams.push(params)
         return { rows: [] }
       }


### PR DESCRIPTION
Modify spark-publish to include another telemetry field: load factor.  I.e. what fraction of measurements waiting to be published we were able to process.

The load factor should be under 100% most time. If it only occasionally goes over 100% then the service should be able to eventually self-heal.  The trouble starts when we are consistently over 100% - the backlog of unpublished measurements is growing faster than we can process it.
