### PR TITLE
add caching for GET /rounds/current

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,9 +141,10 @@ const getMeasurement = async (req, res, client, measurementId) => {
 const getRoundDetails = async (req, res, client, getCurrentRound, roundParam) => {
   const roundNumber = await parseRoundNumberOrCurrent(getCurrentRound, roundParam)
 
-  if (roundParam === 'current') {
-    res.setHeader('cache-control', 'no-store')
-  }
+  res.setHeader(
+    'cache-control',
+    `max-age=${roundParam === 'current' ? 60 : 31536000}}`
+  )
 
   await replyWithDetailsForRoundNumber(res, client, roundNumber)
 }


### PR DESCRIPTION
After merging, adjust https://dash.cloudflare.com/37573110e38849a343d93b727953188f/filspark.com/caching/cache-rules/7cc5c26ebc3c400c9666c5a0f83ac50d to read the `cache-control` header again