### PR TITLE
perf: index frequent queries

### DIFF
--- a/migrations/028.do.index_unpublished_tasks.sql
+++ b/migrations/028.do.index_unpublished_tasks.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY measurements_not_published
+ON measurements (published_as)
+WHERE published_as IS NULL;

--- a/migrations/029.do.index_retrieval_tasks_round_id.sql
+++ b/migrations/029.do.index_retrieval_tasks_round_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY retrieval_tasks_round_id ON retrieval_tasks (round_id);


### PR DESCRIPTION
I examined the slowest queries recorded by `pg_stats_statements` plugin:

1. Find up to N unpublished measurements
2. Count all unpublished measurements
3. Find tasks for the given round

This pull request adds indices to speed up these queries.

Links:
- https://github.com/filecoin-station/spark-api/issues/144

**perf: index unpublished measurements**

1939 ms -> 31 ms

Before:

```
explain analyze SELECT COUNT(*) FROM measurements WHERE published_as IS NULL;
                                                                    QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=615123.03..615123.04 rows=1 width=8) (actual time=1934.862..1937.937 rows=1 loops=1)
   ->  Gather  (cost=615122.81..615123.02 rows=2 width=8) (actual time=1934.630..1937.907 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=614122.81..614122.82 rows=1 width=8) (actual time=1907.215..1907.216 rows=1 loops=3)
               ->  Parallel Seq Scan on measurements  (cost=0.00..614055.69 rows=26850 width=0) (actual time=1623.262..1907.142 rows=877 loops=3)
                     Filter: (published_as IS NULL)
                     Rows Removed by Filter: 3958353
 Planning Time: 0.270 ms
 JIT:
   Functions: 17
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 1.886 ms, Inlining 90.878 ms, Optimization 68.838 ms, Emission 41.483 ms, Total 203.085 ms
 Execution Time: 1939.514 ms
```

After:

```
explain analyze SELECT COUNT(*) FROM measurements WHERE published_as IS NULL;
                                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=172711.16..172711.17 rows=1 width=8) (actual time=28.338..28.341 rows=1 loops=1)
   ->  Bitmap Heap Scan on measurements  (cost=48.29..172562.69 rows=59388 width=0) (actual time=21.834..27.478 rows=2632 loops=1)
         Recheck Cond: (published_as IS NULL)
         Heap Blocks: exact=395
         ->  Bitmap Index Scan on measurements_not_published  (cost=0.00..33.44 rows=59388 width=0) (actual time=0.212..0.213 rows=2632 loops=1)
 Planning Time: 4.088 ms
 JIT:
   Functions: 5
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 1.446 ms, Inlining 0.000 ms, Optimization 0.939 ms, Emission 20.537 ms, Total 22.921 ms
 Execution Time: 31.289 ms
(11 rows)
```

**perf: index retrieval tasks' round id**

7.2 ms -> 0.2 ms

Before:

```
explain analyze SELECT * FROM retrieval_tasks WHERE round_id = 213;
                                                 QUERY PLAN
-------------------------------------------------------------------------------------------------------------
 Seq Scan on retrieval_tasks  (cost=0.00..118.00 rows=1 width=148) (actual time=7.156..7.157 rows=0 loops=1)
   Filter: (round_id = 213)
   Rows Removed by Filter: 1600
 Planning Time: 5.548 ms
 Execution Time: 7.246 ms
(5 rows)
```

After:

```
explain analyze SELECT * FROM retrieval_tasks WHERE round_id = 213;
                                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using retrieval_tasks_round_id on retrieval_tasks  (cost=0.28..7.53 rows=1 width=148) (actual time=0.062..0.063 rows=0 loops=1)
   Index Cond: (round_id = 213)
 Planning Time: 3.168 ms
 Execution Time: 0.220 ms
(4 rows)
```
