### PR TITLE
perf: better caching of current round details

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -55,9 +55,9 @@ client.on('error', err => {
 
 const getCurrentRound = await createRoundGetter(client)
 
-const round = await getCurrentRound()
+const round = getCurrentRound()
 assert(!!round, 'cannot obtain the current Spark round number')
-console.log('SPARK round number at service startup:', round)
+console.log('SPARK round number at service startup:', round.sparkRoundNumber)
 
 const handler = await createHandler({
   client,

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const handler = async (req, res, client, getCurrentRound, domain) => {
 }
 
 const createMeasurement = async (req, res, client, getCurrentRound) => {
-  console.log('round', getCurrentRound())
   const { sparkRoundNumber } = getCurrentRound()
   const body = await getRawBody(req, { limit: '100kb' })
   const measurement = JSON.parse(body)

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ const getRoundDetails = async (req, res, client, getCurrentRound, roundParam) =>
   }
 
   // TODO(bajtos) Remove this branch and return 404
-  const roundNumber = await parseRoundNumberOrCurrent(getCurrentRound, roundParam)
+  const roundNumber = parseRoundNumber(roundParam)
   await replyWithDetailsForRoundNumber(res, client, roundNumber)
 }
 
@@ -214,10 +214,7 @@ const getMeridianRoundDetails = async (_req, res, client, meridianAddress, merid
   })
 }
 
-const parseRoundNumberOrCurrent = async (getCurrentRound, roundParam) => {
-  if (roundParam === 'current') {
-    return await getCurrentRound()
-  }
+const parseRoundNumber = (roundParam) => {
   try {
     return BigInt(roundParam)
   } catch (err) {

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -13,18 +13,21 @@ export const TASKS_PER_ROUND = 400
 export async function createRoundGetter (pgClient) {
   const contract = await createMeridianContract()
 
-  let sparkRoundNumber
-  const updateSparkRound = async (meridianRoundIndex) => {
+  let sparkRoundNumber, meridianContractAddress, meridianRoundIndex
+
+  const updateSparkRound = async (newRoundIndex) => {
+    meridianRoundIndex = BigInt(newRoundIndex)
+    meridianContractAddress = contract.address
     sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
-      meridianContractAddress: contract.address,
-      meridianRoundIndex: BigInt(meridianRoundIndex),
+      meridianContractAddress,
+      meridianRoundIndex,
       pgClient
     })
     console.log('SPARK round started: %s', sparkRoundNumber)
   }
 
-  contract.on('RoundStart', (meridianRoundIndex) => {
-    updateSparkRound(meridianRoundIndex).catch(err => {
+  contract.on('RoundStart', (newRoundIndex) => {
+    updateSparkRound(newRoundIndex).catch(err => {
       console.error('Cannot handle RoundStart:', err)
       Sentry.captureException(err)
     })
@@ -32,7 +35,11 @@ export async function createRoundGetter (pgClient) {
 
   await updateSparkRound(await contract.currentRoundIndex())
 
-  return () => sparkRoundNumber
+  return () => ({
+    sparkRoundNumber,
+    meridianContractAddress,
+    meridianRoundIndex
+  })
 }
 
 /*

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -155,19 +155,25 @@ export async function mapCurrentMeridianRoundToSparkRound ({
     )
   }
 
-  await maybeCreateSparkRound(pgClient, sparkRoundNumber)
+  await maybeCreateSparkRound(pgClient, { sparkRoundNumber, meridianContractAddress, meridianRoundIndex })
 
   return sparkRoundNumber
 }
 
-export async function maybeCreateSparkRound (pgClient, sparkRoundNumber) {
+export async function maybeCreateSparkRound (pgClient, {
+  sparkRoundNumber,
+  meridianContractAddress,
+  meridianRoundIndex
+}) {
   const { rowCount } = await pgClient.query(`
     INSERT INTO spark_rounds
-    (id, created_at)
-    VALUES ($1, now())
+    (id, created_at, meridian_address, meridian_round)
+    VALUES ($1, now(), $2, $3)
     ON CONFLICT DO NOTHING
   `, [
-    sparkRoundNumber
+    sparkRoundNumber,
+    meridianContractAddress,
+    meridianRoundIndex
   ])
 
   if (rowCount) {

--- a/migrations/030.do.meridian-details-in-spark-rounds.sql
+++ b/migrations/030.do.meridian-details-in-spark-rounds.sql
@@ -1,0 +1,15 @@
+ALTER TABLE spark_rounds
+ADD COLUMN meridian_address TEXT;
+
+ALTER TABLE spark_rounds
+ADD COLUMN meridian_round BIGINT;
+
+CREATE INDEX spark_rounds_meridian ON spark_rounds(meridian_address, meridian_round);
+
+ALTER TABLE retrieval_tasks
+DROP CONSTRAINT retrieval_tasks_round_id_fkey;
+
+ALTER TABLE retrieval_tasks
+ADD CONSTRAINT retrieval_tasks_round_id_fkey
+FOREIGN KEY (round_id) REFERENCES spark_rounds(id) ON DELETE CASCADE;
+

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -36,6 +36,8 @@ describe('Round Tracker', () => {
       let sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
       assertApproximately(sparkRounds[0].created_at, new Date(), 30_000)
+      assert.strictEqual(sparkRounds[0].meridian_address, '0x1a')
+      assert.strictEqual(sparkRounds[0].meridian_round, '120')
 
       // first round number was correctly initialised
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1a'), '1')
@@ -49,6 +51,8 @@ describe('Round Tracker', () => {
       sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1', '2'])
       assertApproximately(sparkRounds[1].created_at, new Date(), 30_000)
+      assert.strictEqual(sparkRounds[1].meridian_address, '0x1a')
+      assert.strictEqual(sparkRounds[1].meridian_round, '121')
 
       // first round number was not changed
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1a'), '1')
@@ -74,6 +78,10 @@ describe('Round Tracker', () => {
       // first round number was correctly initialised
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1b'), '2')
 
+      const { rows: [round2] } = await pgClient.query('SELECT * FROM spark_rounds WHERE id = 2')
+      assert.strictEqual(round2.meridian_address, '0x1b')
+      assert.strictEqual(round2.meridian_round, '10')
+
       // Double check that the next meridian round will map correctly
       // New contract version `0x1b`
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
@@ -82,6 +90,10 @@ describe('Round Tracker', () => {
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 3n)
+
+      const { rows: [round3] } = await pgClient.query('SELECT * FROM spark_rounds WHERE id = 3')
+      assert.strictEqual(round3.meridian_address, '0x1b')
+      assert.strictEqual(round3.meridian_round, '11')
 
       // first round number was not changed
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1b'), '2')
@@ -101,6 +113,8 @@ describe('Round Tracker', () => {
       let sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
       assertApproximately(sparkRounds[0].created_at, now, 30_000)
+      assert.strictEqual(sparkRounds[0].meridian_address, '0x1a')
+      assert.strictEqual(sparkRounds[0].meridian_round, '1')
 
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
@@ -111,6 +125,8 @@ describe('Round Tracker', () => {
       sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
       assertApproximately(sparkRounds[0].created_at, now, 30_000)
+      assert.strictEqual(sparkRounds[0].meridian_address, '0x1a')
+      assert.strictEqual(sparkRounds[0].meridian_round, '1')
     })
 
     it('creates tasks when a new round starts', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,11 @@ describe('Routes', () => {
   before(async () => {
     client = new pg.Client({ connectionString: DATABASE_URL })
     await client.connect()
-    await maybeCreateSparkRound(client, currentSparkRoundNumber)
+    await maybeCreateSparkRound(client, {
+      sparkRoundNumber: currentSparkRoundNumber,
+      meridianContractAddress: '0x1a',
+      meridianRoundIndex: 123n
+    })
     const handler = await createHandler({
       client,
       logger: {
@@ -256,6 +260,7 @@ describe('Routes', () => {
   describe('GET /round/meridian/:address/:round', () => {
     before(async () => {
       await client.query('DELETE FROM meridian_contract_versions')
+      await client.query('DELETE FROM spark_rounds')
 
       // round 1 managed by old contract version
       let num = await mapCurrentMeridianRoundToSparkRound({
@@ -316,6 +321,16 @@ describe('Routes', () => {
   })
 
   describe('GET /rounds/current', () => {
+    before(async () => {
+      await client.query('DELETE FROM meridian_contract_versions')
+      await client.query('DELETE FROM spark_rounds')
+      await maybeCreateSparkRound(client, {
+        sparkRoundNumber: currentSparkRoundNumber,
+        meridianContractAddress: '0x1a',
+        meridianRoundIndex: 123n
+      })
+    })
+
     it('returns all properties of the current round', async () => {
       const res = await fetch(`${spark}/rounds/current`)
       await assertResponseStatus(res, 200)
@@ -336,6 +351,16 @@ describe('Routes', () => {
   })
 
   describe('GET /rounds/:id', () => {
+    before(async () => {
+      await client.query('DELETE FROM meridian_contract_versions')
+      await client.query('DELETE FROM spark_rounds')
+      await maybeCreateSparkRound(client, {
+        sparkRoundNumber: currentSparkRoundNumber,
+        meridianContractAddress: '0x1a',
+        meridianRoundIndex: 123n
+      })
+    })
+
     it('returns 404 when the round does not exist', async () => {
       const res = await fetch(`${spark}/rounds/${currentSparkRoundNumber * 2n}`)
       await assertResponseStatus(res, 404)

--- a/test/test.js
+++ b/test/test.js
@@ -43,8 +43,12 @@ describe('Routes', () => {
         info () {},
         error (...args) { console.error(...args) }
       },
-      async getCurrentRound () {
-        return currentSparkRoundNumber
+      getCurrentRound () {
+        return {
+          sparkRoundNumber: currentSparkRoundNumber,
+          meridianContractAddress: '0x1a',
+          meridianRoundIndex: 123n
+        }
       },
       domain: '127.0.0.1'
     })
@@ -331,7 +335,14 @@ describe('Routes', () => {
       })
     })
 
-    it('returns all properties of the current round', async () => {
+    it('returns temporary redirect with a short max-age', async () => {
+      const res = await fetch(`${spark}/rounds/current`, { redirect: 'manual' })
+      await assertResponseStatus(res, 302)
+      assert.strictEqual(res.headers.get('location'), '/rounds/meridian/0x1a/123')
+      assert.strictEqual(res.headers.get('cache-control'), 'max-age=1')
+    })
+
+    it('returns all properties of the current round after redirect', async () => {
       const res = await fetch(`${spark}/rounds/current`)
       await assertResponseStatus(res, 200)
       const body = await res.json()
@@ -394,8 +405,12 @@ describe('Routes', () => {
             info () {},
             error (...args) { console.error(...args) }
           },
-          async getCurrentRound () {
-            return currentSparkRoundNumber
+          getCurrentRound () {
+            return {
+              sparkRoundNumber: currentSparkRoundNumber,
+              meridianContractAddress: '0x1a',
+              meridianRoundIndex: 123n
+            }
           },
           domain: 'foobar'
         })


### PR DESCRIPTION
Rework the implementation of `GET /rounds/current` to redirect to a permalink `GET /rounds/meridian/{addr}/{round}`. This allows us to cache better the data queried from our database.

1. The redirection logic does not need the database; it builds the new location using in-memory data.

   In the future, we can rework spark-checker to determine the current round locally by querying the on-chain state of the Meridian contract.

2. The response for the permalink for a given meridian round is immutable and, therefore, can be cached forever. If all works out as expected, we should see only one request per round, and the CDN cache will take care of the rest.

I have also improved the database schema to store the meridian contract address and round index in `spark_rounds` in order to enable fast lookup of Spark rounds from Meridian rounds,

This PR supersedes and closes #143

Links:
- https://github.com/filecoin-station/spark-api/issues/144