### PR TITLE
fix: migrate db schema before current round init

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -7,6 +7,7 @@ import fs from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRoundGetter } from '../lib/round-tracker.js'
+import { migrate } from '../lib/migrate.js'
 import assert from 'node:assert'
 
 const {
@@ -52,6 +53,7 @@ client.on('error', err => {
   // https://github.com/brianc/node-postgres/issues/1324#issuecomment-308778405
   console.error('An idle client has experienced an error', err.stack)
 })
+await migrate(client)
 
 const getCurrentRound = await createRoundGetter(client)
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import { json } from 'http-responders'
 import Sentry from '@sentry/node'
-import { migrate } from './lib/migrate.js'
 import getRawBody from 'raw-body'
 import assert from 'http-assert'
 import { validate } from './lib/validate.js'
@@ -271,7 +270,6 @@ export const createHandler = async ({
   getCurrentRound,
   domain
 }) => {
-  await migrate(client)
   return (req, res) => {
     const start = new Date()
     logger.info(`${req.method} ${req.url} ...`)


### PR DESCRIPTION
Deployment of https://github.com/filecoin-station/spark-api/pull/147 is failing because at startup, we are updating `spark_rounds` table with `meridian_contract` and `meridian_round` before running the database schema migration.

This PR changes the initialisation order: db migrations first and everything else afterwards.

