### PR TITLE
fix: wrap creation of new rounds in transaction

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -10,7 +10,15 @@ import { createMeridianContract } from './ie-contract.js'
 // We will need to tweak this value based on measurements; that's why I put it here as a constant.
 export const TASKS_PER_ROUND = 400
 
-export async function createRoundGetter (pgClient) {
+/**
+ * @param {import('pg').Pool} pgPool
+ * @returns {() => {
+ *  sparkRoundNumber: bigint;
+ *  meridianContractAddress: string;
+ *  meridianRoundIndex: bigint;
+ * }}
+ */
+export async function createRoundGetter (pgPool) {
   const contract = await createMeridianContract()
 
   let sparkRoundNumber, meridianContractAddress, meridianRoundIndex
@@ -18,12 +26,22 @@ export async function createRoundGetter (pgClient) {
   const updateSparkRound = async (newRoundIndex) => {
     meridianRoundIndex = BigInt(newRoundIndex)
     meridianContractAddress = contract.address
-    sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
-      meridianContractAddress,
-      meridianRoundIndex,
-      pgClient
-    })
-    console.log('SPARK round started: %s', sparkRoundNumber)
+
+    const pgClient = await pgPool.connect()
+    try {
+      await pgClient.query('BEGIN')
+      sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
+        meridianContractAddress,
+        meridianRoundIndex,
+        pgClient
+      })
+      await pgClient.query('COMMIT')
+      console.log('SPARK round started: %s', sparkRoundNumber)
+    } catch (err) {
+      await pgClient.query('ROLLBACK')
+    } finally {
+      pgClient.release()
+    }
   }
 
   contract.on('RoundStart', (newRoundIndex) => {


### PR DESCRIPTION
I am observing different number of retrieval tasks returned in the response to the following request:

```
GET /rounds/meridian/0xaaef78eaf86dcf34f275288752e892424dda9341/410
```

I suspect this depends on which Cloudfare enpoint I hit. When I add `/?fresh=1` to the URL, I bypass the CDN and get a correct response with 400 tasks.

I think this is caused when Cloudfare hits our endpoint while we are still populating `retrieval_tasks` table for the recently started round.

In this pull request, I am wrapping that code in a new SQL transaction, to make the creation of new round and its tasks atomic.

Links:
- https://github.com/filecoin-station/spark-api/pull/147
- https://github.com/filecoin-station/spark-api/issues/144