### PR TITLE
fix: preserve date values set to `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,10 +93,10 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
     measurement.protocol,
     measurement.participantAddress,
     measurement.timeout || false,
-    new Date(measurement.startAt),
+    parseDateStringOrNull(measurement.startAt),
     measurement.statusCode,
-    new Date(measurement.firstByteAt),
-    new Date(measurement.endAt),
+    parseDateStringOrNull(measurement.firstByteAt),
+    parseDateStringOrNull(measurement.endAt),
     measurement.byteLength,
     measurement.attestation,
     inetGroup,
@@ -284,4 +284,9 @@ export const createHandler = async ({
         }
       })
   }
+}
+
+const parseDateStringOrNull = (strOrNull) => {
+  if (strOrNull === undefined || strOrNull === null) return undefined
+  return new Date(strOrNull)
 }

--- a/index.js
+++ b/index.js
@@ -93,10 +93,10 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
     measurement.protocol,
     measurement.participantAddress,
     measurement.timeout || false,
-    parseDateStringOrNull(measurement.startAt),
+    parseOptionalDate(measurement.startAt),
     measurement.statusCode,
-    parseDateStringOrNull(measurement.firstByteAt),
-    parseDateStringOrNull(measurement.endAt),
+    parseOptionalDate(measurement.firstByteAt),
+    parseOptionalDate(measurement.endAt),
     measurement.byteLength,
     measurement.attestation,
     inetGroup,
@@ -286,7 +286,17 @@ export const createHandler = async ({
   }
 }
 
-const parseDateStringOrNull = (strOrNull) => {
-  if (strOrNull === undefined || strOrNull === null) return undefined
-  return new Date(strOrNull)
+/**
+ * Parse a date string field that may be `undefined` or `null`.
+ *
+ * - undefined -> undefined
+ * - null -> undefined
+ * - "iso-date-string" -> new Date("iso-date-string")
+ *
+ * @param {string | null | undefined} str
+ * @returns {Date | undefined}
+ */
+const parseOptionalDate = (str) => {
+  if (str === undefined || str === null) return undefined
+  return new Date(str)
 }

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -98,7 +98,7 @@ describe('integration', () => {
       startAt: new Date('2023-09-18T13:33:51.239Z'),
       statusCode: 200,
       firstByteAt: new Date('2023-09-18T13:33:51.239Z'),
-      endAt: new Date('2023-09-18T13:33:51.239Z'),
+      endAt: null,
       byteLength: 100,
       attestation: 'json.sig',
       inetGroup: 'MTIzNDU2Nzg',
@@ -208,6 +208,7 @@ describe('integration', () => {
     assert.strictEqual(published.cid, measurementRecorded.cid)
     assert.strictEqual(published.inet_group, measurementRecorded.inetGroup)
     assert.strictEqual(published.car_too_large, measurementRecorded.carTooLarge)
+    assert.strictEqual(published.end_at, null)
     // TODO: test other fields
 
     // We are publishing records with invalid wallet addresses too


### PR DESCRIPTION
Before this change, when the client sent `end_at: null`, we would convert that value to `Date(null)`, which is the Unix epoch.

After this change, we preserve null values as null.

Links:
- https://github.com/filecoin-station/spark/issues/43
