### PR TITLE
Move `publish()` to own CLI, for memory

### DIFF
--- a/spark-publish/bin/publish-batch.js
+++ b/spark-publish/bin/publish-batch.js
@@ -1,0 +1,64 @@
+// Run `publish()` in a short lived script, to help with memory issues
+
+import Sentry from '@sentry/node'
+import { publish } from '../index.js'
+import pg from 'pg'
+import * as Client from '@web3-storage/w3up-client'
+import { ed25519 } from '@ucanto/principal'
+import { CarReader } from '@ipld/car'
+import { importDAG } from '@ucanto/core/delegation'
+import { ethers } from 'ethers'
+import { IE_CONTRACT_ABI, IE_CONTRACT_ADDRESS, RPC_URL } from '../ie-contract-config.js'
+import assert from 'node:assert'
+
+const {
+  DATABASE_URL,
+  SENTRY_ENVIRONMENT = 'development',
+  WALLET_SEED,
+  MAX_MEASUREMENTS_PER_ROUND = 1000,
+  // See https://web3.storage/docs/how-to/upload/#bring-your-own-agent
+  W3UP_PRIVATE_KEY,
+  W3UP_PROOF
+} = process.env
+
+Sentry.init({
+  dsn: 'https://b5bd47a165dcd801408bc14d9fcbc1c3@o1408530.ingest.sentry.io/4505861814878208',
+  environment: SENTRY_ENVIRONMENT,
+  tracesSampleRate: 0.1
+})
+
+assert(WALLET_SEED, 'WALLET_SEED required')
+assert(W3UP_PRIVATE_KEY, 'W3UP_PRIVATE_KEY required')
+assert(W3UP_PROOF, 'W3UP_PROOF required')
+
+const client = new pg.Pool({ connectionString: DATABASE_URL })
+
+async function parseProof (data) {
+  const blocks = []
+  const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'))
+  for await (const block of reader.blocks()) {
+    blocks.push(block)
+  }
+  return importDAG(blocks)
+}
+
+const principal = ed25519.Signer.parse(W3UP_PRIVATE_KEY)
+const web3Storage = await Client.create({ principal })
+const proof = await parseProof(W3UP_PROOF)
+const space = await web3Storage.addSpace(proof)
+await web3Storage.setCurrentSpace(space.did())
+
+const provider = new ethers.providers.JsonRpcProvider(RPC_URL)
+const signer = ethers.Wallet.fromMnemonic(WALLET_SEED).connect(provider)
+const ieContract = new ethers.Contract(
+  IE_CONTRACT_ADDRESS,
+  IE_CONTRACT_ABI,
+  provider
+).connect(signer)
+
+await publish({
+  client,
+  web3Storage,
+  ieContract,
+  maxMeasurements: MAX_MEASUREMENTS_PER_ROUND
+})

--- a/spark-publish/bin/publish-batch.js
+++ b/spark-publish/bin/publish-batch.js
@@ -72,3 +72,4 @@ try {
     console.error(err)
   }
 }
+process.exit(0)

--- a/spark-publish/bin/spark-publish.js
+++ b/spark-publish/bin/spark-publish.js
@@ -1,17 +1,14 @@
-import pg from 'pg'
-import { startPublishLoop } from '../index.js'
-import { IE_CONTRACT_ABI, IE_CONTRACT_ADDRESS, RPC_URL } from '../ie-contract-config.js'
 import Sentry from '@sentry/node'
 import assert from 'node:assert'
-import * as Client from '@web3-storage/w3up-client'
-import { ed25519 } from '@ucanto/principal'
-import { CarReader } from '@ipld/car'
-import { importDAG } from '@ucanto/core/delegation'
-import { ethers } from 'ethers'
 import { newDelegatedEthAddress } from '@glif/filecoin-address'
+import timers from 'node:timers/promises'
+import { ethers } from 'ethers'
+import { spawn } from 'node:child_process'
+import { once } from 'events'
+import { RPC_URL } from '../ie-contract-config.js'
+import { fileURLToPath } from 'node:url'
 
 const {
-  DATABASE_URL,
   SENTRY_ENVIRONMENT = 'development',
   WALLET_SEED,
   MIN_ROUND_LENGTH_SECONDS = 120,
@@ -31,30 +28,10 @@ assert(WALLET_SEED, 'WALLET_SEED required')
 assert(W3UP_PRIVATE_KEY, 'W3UP_PRIVATE_KEY required')
 assert(W3UP_PROOF, 'W3UP_PROOF required')
 
-const client = new pg.Pool({ connectionString: DATABASE_URL })
-
-async function parseProof (data) {
-  const blocks = []
-  const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'))
-  for await (const block of reader.blocks()) {
-    blocks.push(block)
-  }
-  return importDAG(blocks)
-}
-
-const principal = ed25519.Signer.parse(W3UP_PRIVATE_KEY)
-const web3Storage = await Client.create({ principal })
-const proof = await parseProof(W3UP_PROOF)
-const space = await web3Storage.addSpace(proof)
-await web3Storage.setCurrentSpace(space.did())
+const minRoundLength = Number(MIN_ROUND_LENGTH_SECONDS) * 1000
 
 const provider = new ethers.providers.JsonRpcProvider(RPC_URL)
 const signer = ethers.Wallet.fromMnemonic(WALLET_SEED).connect(provider)
-const ieContract = new ethers.Contract(
-  IE_CONTRACT_ADDRESS,
-  IE_CONTRACT_ABI,
-  provider
-).connect(signer)
 
 console.log(
   'Wallet address:',
@@ -62,10 +39,26 @@ console.log(
   newDelegatedEthAddress(signer.address, 'f').toString()
 )
 
-await startPublishLoop({
-  client,
-  web3Storage,
-  ieContract,
-  minRoundLength: MIN_ROUND_LENGTH_SECONDS * 1000,
-  maxMeasurementsPerRound: MAX_MEASUREMENTS_PER_ROUND
-})
+while (true) {
+  const lastStart = new Date()
+  const ps = spawn(
+    'node',
+    [fileURLToPath(new URL('publish-batch.js', import.meta.url))],
+    {
+      env: {
+        ...process.env,
+        MIN_ROUND_LENGTH_SECONDS,
+        MAX_MEASUREMENTS_PER_ROUND,
+        WALLET_SEED,
+        W3UP_PRIVATE_KEY,
+        W3UP_PROOF
+      }
+    }
+  )
+  ps.stdout.pipe(process.stdout)
+  ps.stderr.pipe(process.stderr)
+  const [code] = await once(ps, 'exit')
+  assert.strictEqual(code, 0, `Bad exit code: ${code}`)
+  const dt = new Date() - lastStart
+  if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)
+}

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -1,6 +1,5 @@
 /* global File */
 
-import timers from 'node:timers/promises'
 import { record } from './lib/telemetry.js'
 
 export const publish = async ({
@@ -93,24 +92,4 @@ export const publish = async ({
     )
     point.intField('add_measurements_duration_ms', ieAddMeasurementsDuration)
   })
-}
-
-export const startPublishLoop = async ({
-  client,
-  web3Storage,
-  ieContract,
-  minRoundLength = 30_000,
-  maxMeasurementsPerRound = 1000
-}) => {
-  while (true) {
-    const lastStart = new Date()
-    await publish({
-      client,
-      web3Storage,
-      ieContract,
-      maxMeasurements: maxMeasurementsPerRound
-    })
-    const dt = new Date() - lastStart
-    if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)
-  }
 }

--- a/spark-publish/lib/telemetry.js
+++ b/spark-publish/lib/telemetry.js
@@ -5,7 +5,7 @@ const influx = new InfluxDB({
   // spark-publish-write
   token: 'Zkqa_s7mI0W_WKI6DUmu-iRnQkCvwNaQfbPK_zT7I6iYYaC2C1kokdlhO2jb4tjRcAJQHQXAGnrdD3vqlMZ63g=='
 })
-const writeClient = influx.getWriteApi(
+export const writeClient = influx.getWriteApi(
   'Filecoin Station', // org
   'spark-publish', // bucket
   'ns' // precision


### PR DESCRIPTION
We have two CLIs now: Once that runs the loop, and one that performs one iteration of the loop.

This way we shouldn't have any long-running memory gc issues