### PR TITLE
feat: bump up tasks/round to 4000

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -8,7 +8,7 @@ import { createMeridianContract } from './ie-contract.js'
 // for more details, this constant represents TC (tasks per committee).
 //
 // We will need to tweak this value based on measurements; that's why I put it here as a constant.
-export const TASKS_PER_ROUND = 400
+export const TASKS_PER_ROUND = 4000
 
 /**
  * @param {import('pg').Pool} pgPool
@@ -209,25 +209,14 @@ export async function maybeCreateSparkRound (pgClient, {
 }
 
 async function defineTasksForRound (pgClient, sparkRoundNumber) {
-  const { rows: templates } = await pgClient.query(`
-    SELECT cid, provider_address, protocol
+  await pgClient.query(`
+    INSERT INTO retrieval_tasks (round_id, cid, provider_address, protocol)
+    SELECT $1 as round_id, cid, provider_address, protocol
     FROM retrieval_templates
     ORDER BY random()
-    LIMIT $1
+    LIMIT $2;
   `, [
+    sparkRoundNumber,
     TASKS_PER_ROUND
   ])
-
-  // TODO: optimise this code into a single SQL query
-  for (const t of templates) {
-    await pgClient.query(`
-      INSERT INTO retrieval_tasks (round_id, cid, provider_address, protocol)
-      VALUES ($1, $2, $3, $4)
-    `, [
-      sparkRoundNumber,
-      t.cid,
-      t.provider_address,
-      t.protocol
-    ])
-  }
 }


### PR DESCRIPTION
We have currently more than 500k retrieval templates to pick from, and the network has ~20k nodes, so let's spread the load on SPs.

This is a follow-up for https://github.com/filecoin-station/fil-deal-ingester/pull/8

