### PR TITLE
feat: maxTasksPerNode in round details

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,7 @@ const replyWithDetailsForRoundNumber = async (res, client, roundNumber) => {
 
   json(res, {
     roundId: round.id.toString(),
+    maxTasksPerNode: round.max_tasks_per_node,
     retrievalTasks: tasks.map(t => ({
       cid: t.cid,
       providerAddress: t.provider_address,
@@ -204,6 +205,7 @@ const getMeridianRoundDetails = async (_req, res, client, meridianAddress, merid
   res.setHeader('cache-control', `public, max-age=${ONE_YEAR_IN_SECONDS}, immutable`)
   json(res, {
     roundId: round.id.toString(),
+    maxTasksPerNode: round.max_tasks_per_node,
     retrievalTasks: tasks.map(t => ({
       cid: t.cid,
       providerAddress: t.provider_address,

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -10,6 +10,9 @@ import { createMeridianContract } from './ie-contract.js'
 // We will need to tweak this value based on measurements; that's why I put it here as a constant.
 export const TASKS_PER_ROUND = 4000
 
+// How many tasks is each SPARK checker node expected to complete every round (at most).
+export const MAX_TASKS_PER_NODE = 60
+
 /**
  * @param {import('pg').Pool} pgPool
  * @returns {() => {
@@ -192,13 +195,14 @@ export async function maybeCreateSparkRound (pgClient, {
 }) {
   const { rowCount } = await pgClient.query(`
     INSERT INTO spark_rounds
-    (id, created_at, meridian_address, meridian_round)
-    VALUES ($1, now(), $2, $3)
+    (id, created_at, meridian_address, meridian_round, max_tasks_per_node)
+    VALUES ($1, now(), $2, $3, $4)
     ON CONFLICT DO NOTHING
   `, [
     sparkRoundNumber,
     meridianContractAddress,
-    meridianRoundIndex
+    meridianRoundIndex,
+    MAX_TASKS_PER_NODE
   ])
 
   if (rowCount) {

--- a/migrations/034.do.round-max-tasks-per-node.sql
+++ b/migrations/034.do.round-max-tasks-per-node.sql
@@ -1,0 +1,4 @@
+ALTER TABLE spark_rounds
+ADD COLUMN max_tasks_per_node INT NOT NULL
+-- 60 minutes/round * 6 tasks/minute, based on hard-coded delay of 10s between tasks
+DEFAULT 360;

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -167,6 +167,21 @@ describe('Round Tracker', () => {
         assert.strictEqual(BigInt(t.round_id), firstRoundNumber)
       }
     })
+
+    it('sets tasks_per_round', async () => {
+      const meridianRoundIndex = 1n
+      const meridianContractAddress = '0x1a'
+
+      const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
+        meridianContractAddress,
+        meridianRoundIndex,
+        pgClient
+      })
+      assert.strictEqual(sparkRoundNumber, 1n)
+      const sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
+      assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
+      assert.strictEqual(sparkRounds[0].max_tasks_per_node, 60)
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,8 @@ import pg from 'pg'
 import {
   TASKS_PER_ROUND,
   maybeCreateSparkRound,
-  mapCurrentMeridianRoundToSparkRound
+  mapCurrentMeridianRoundToSparkRound,
+  MAX_TASKS_PER_NODE
 } from '../lib/round-tracker.js'
 
 const { DATABASE_URL } = process.env
@@ -335,7 +336,8 @@ describe('Routes', () => {
       const { retrievalTasks, ...details } = await res.json()
 
       assert.deepStrictEqual(details, {
-        roundId: '2'
+        roundId: '2',
+        maxTasksPerNode: MAX_TASKS_PER_NODE
       })
       assert.strictEqual(retrievalTasks.length, TASKS_PER_ROUND)
     })
@@ -346,7 +348,8 @@ describe('Routes', () => {
       const { retrievalTasks, ...details } = await res.json()
 
       assert.deepStrictEqual(details, {
-        roundId: '1'
+        roundId: '1',
+        maxTasksPerNode: MAX_TASKS_PER_NODE
       })
       assert.strictEqual(retrievalTasks.length, TASKS_PER_ROUND)
     })
@@ -387,6 +390,7 @@ describe('Routes', () => {
 
       assert.deepStrictEqual(Object.keys(body), [
         'roundId',
+        'maxTasksPerNode',
         'retrievalTasks'
       ])
       assert.strictEqual(body.roundId, currentSparkRoundNumber.toString())
@@ -427,6 +431,7 @@ describe('Routes', () => {
 
       assert.deepStrictEqual(Object.keys(body), [
         'roundId',
+        'maxTasksPerNode',
         'retrievalTasks'
       ])
       assert.strictEqual(body.roundId, currentSparkRoundNumber.toString())


### PR DESCRIPTION
Add a new per-round configuration parameter allowing us to tweak how many retrieval requests are performed by each checker node.

The concept of "tasks per node" is described in [SPARK tasking v2](https://www.notion.so/pl-strflt/SPARK-tasking-v2-604e26d57f6b4892946525bcb3a77104?pvs=4#ded1cd98c2664a2289453d38e2715643).

Links:
- https://github.com/filecoin-station/roadmap/issues/52
