### PR TITLE
Implement new RPC_URL rotation strategy

### DIFF
--- a/spark-publish/bin/spark-publish.js
+++ b/spark-publish/bin/spark-publish.js
@@ -6,6 +6,7 @@ import { ethers } from 'ethers'
 import { spawn } from 'node:child_process'
 import { once } from 'events'
 import { fileURLToPath } from 'node:url'
+import { rpcUrls } from '../ie-contract-config.js'
 
 const {
   SENTRY_ENVIRONMENT = 'development',
@@ -37,6 +38,8 @@ console.log(
   newDelegatedEthAddress(signer.address, 'f').toString()
 )
 
+let rpcUrlIndex = 0
+
 while (true) {
   const lastStart = new Date()
   const ps = spawn(
@@ -49,7 +52,8 @@ while (true) {
         MAX_MEASUREMENTS_PER_ROUND,
         WALLET_SEED,
         W3UP_PRIVATE_KEY,
-        W3UP_PROOF
+        W3UP_PROOF,
+        RPC_URLS: rpcUrls[rpcUrlIndex % rpcUrls.length]
       }
     }
   )
@@ -59,6 +63,7 @@ while (true) {
   if (code !== 0) {
     console.error(`Bad exit code: ${code}`)
     Sentry.captureMessage(`Bad exit code: ${code}`)
+    rpcUrlIndex++
   }
   const dt = new Date() - lastStart
   if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)

--- a/spark-publish/ie-contract-config.js
+++ b/spark-publish/ie-contract-config.js
@@ -20,5 +20,6 @@ const IE_CONTRACT_ABI = JSON.parse(
 export {
   IE_CONTRACT_ADDRESS,
   RPC_URL,
+  rpcUrls,
   IE_CONTRACT_ABI
 }


### PR DESCRIPTION
Stick with one JSON-RPC provider until it fails. This has the advantage that on downtime we don't keep retrying the same provider every other request
