### PR TITLE
feat: keep track of committed CIDs

### DIFF
--- a/migrations/035.do.commitments.sql
+++ b/migrations/035.do.commitments.sql
@@ -1,0 +1,6 @@
+CREATE TABLE commitments (
+  cid TEXT NOT NULL PRIMARY KEY,
+  published_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX commitments_published_at ON commitments (published_at);

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -76,6 +76,12 @@ export const publish = async ({
     measurements.map(m => m.id)
   ])
 
+  // Record the commitment for future queries
+  // TODO: store also ieContract.address and roundIndex
+  await client.query('INSERT INTO commitments (cid, published_at) VALUES ($1, $2)', [
+    cid.toString(), new Date()
+  ])
+
   // TODO: Add cleanup
   // We're not sure if we're going to stick with web3.storage, or switch to
   // helia or another tool. Therefore, add this later.


### PR DESCRIPTION
As discussed in [Scaling SPARK PG DB beyond 500 GiB](https://www.notion.so/pl-strflt/Scaling-SPARK-PG-DB-beyond-500-GiB-4d9b6a81e1ac497691440e5a359e979c#047dbd9db86947438d2c5b7d97b3a025), we are considering how to change our database so that we can delete historical measurements while preserving access to this historical data via commitments published to web3.storage (or IPFS in general).

In this pull request, I am proposing a solution:
- Create a new table `commitments` to keep track of all CIDs plus the time of publishing
- When publishing a new commitment, add a new record to this table
- To query historical data in the given date-time interval, we can obtain the list of CIDs published within that interval from the new table, then fetch measurements in each CID via web3.storage HTTP Gateway.

Key insights:
- Our DB is hidden behind a firewall; services like Grafana cannot access it directly. This means the only services that may be accessing the `measurements` table are those running on Fly.io - spark-api, spark-publish, spark-evaluate. 
  - spark-api does not query measurements
  - spark-publish queries only recent measurements that were not published yet
  - spark-evaluate does not access the DB at all

- In the current setup, our DB does not allow us to fetch all measurements submitted for the given Meridian round. My goal is to reduce the space our DB uses, not to add new features.  There is no need to introduce "contract address" and "round index" to the new table yet, despite of what I described in the [design doc](https://www.notion.so/pl-strflt/Scaling-SPARK-PG-DB-beyond-500-GiB-4d9b6a81e1ac497691440e5a359e979c#047dbd9db86947438d2c5b7d97b3a025).

- As far as I know, when we are manually analysing measurements using SQL queries, we always limit the query to a certain date-time range based on the `measurement.finished_at` column. My proposal preserves this functionality - we can find a superset of all measurements within a given date-time range by selecting all committed CIDs within that same range.

**Next steps after this PR is landed:**
1. Implement and execute a manual migration to populate the `commitments` table for historical commitments. We can use `MAX(finished_at) + INTERVAL '3 minutes'` as a good approximation for `commitments.published_at` values.
2. Implement a periodic cleanup of `measurements` table. We can implement this as a cron job or as another step inside `spark-publish`. (I am leaning towards the latter as it's easier to implement.)

**Out of scope - features we can implement if/when we need them:**
- A script that will obtain all `commitments` within the given date-time range, fetch measurements for those commitments, and output the measurements in a format we can use for further data analysis - e.g. NDJSON or even an SQLite file.
- Add two more columns to the `commitments` table - the address of the currently active Meridian smart contract and the round index associated with the commitment.