### PR TITLE
fix: don't create dangling PG client connection

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -51,7 +51,6 @@ const client = new pg.Pool({
   maxLifetimeSeconds: 60
 })
 
-await client.connect()
 client.on('error', err => {
   // Prevent crashing the process on idle client errors, the pool will recover
   // itself. If all connections are lost, the process will still crash.


### PR DESCRIPTION
Remove the extra line in `bin/spark.js` that was acquiring a new PG connection that was never returned back to the pool.
