### PR TITLE
fix: set Fly primary region to CDG

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,7 @@
 # fly.toml file generated for spark on 2023-05-16T19:09:01+02:00
 
 app = "spark"
+primary_region = "cdg"
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []


### PR DESCRIPTION
Collocate the API service with our database.

After this PR is landed, we need to manually recreate Fly VM machines to move the service from IAD (Virginia/USA) to CDG (Paris, France).
