### PR TITLE
fix composite commitment key

### DIFF
--- a/migrations/037.do.composite-commitment-key.sql
+++ b/migrations/037.do.composite-commitment-key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE commitments
+  DROP CONSTRAINT commitments_pkey,
+  ADD PRIMARY KEY (cid, published_at);


### PR DESCRIPTION
It is possible for two commitments to have the same CID (eg when the round was empty).