### PR TITLE
feat: record `indexerResult` and `carChecksum`

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,8 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
   validate(measurement, 'byteLength', { type: 'number', required: false })
   validate(measurement, 'attestation', { type: 'string', required: false })
   validate(measurement, 'carTooLarge', { type: 'boolean', required: false })
+  validate(measurement, 'carChecksum', { type: 'string', required: false })
+  validate(measurement, 'indexerResult', { type: 'string', required: false })
 
   const inetGroup = await mapRequestToInetGroup(client, req)
 
@@ -83,10 +85,12 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
         attestation,
         inet_group,
         car_too_large,
+        car_checksum,
+        indexer_result,
         completed_at_round
       )
       VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
       )
       RETURNING id
     `, [
@@ -105,6 +109,8 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
     measurement.attestation,
     inetGroup,
     measurement.carTooLarge ?? false,
+    measurement.carChecksum,
+    measurement.indexerResult,
     sparkRoundNumber
   ])
   json(res, { id: rows[0].id })

--- a/migrations/038.do.measurement-indexer-result-car-checksum.sql
+++ b/migrations/038.do.measurement-indexer-result-car-checksum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE measurements ADD COLUMN car_checksum TEXT;
+ALTER TABLE measurements ADD COLUMN indexer_result TEXT;

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -26,6 +26,8 @@ export const publish = async ({
       attestation,
       inet_group,
       car_too_large,
+      car_checksum,
+      indexer_result,
       cid,
       provider_address,
       protocol

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -123,6 +123,8 @@ describe('integration', () => {
       attestation: 'json.sig',
       inetGroup: 'MTIzNDU2Nzg',
       carTooLarge: true,
+      carChecksum: 'somehash',
+      indexerResult: 'ERROR_404',
       round: 42
     }, {
       sparkVersion: '1.2.3',
@@ -224,6 +226,8 @@ describe('integration', () => {
     assert.strictEqual(published.inet_group, measurementRecorded.inetGroup)
     assert.strictEqual(published.car_too_large, measurementRecorded.carTooLarge)
     assert.strictEqual(published.end_at, null)
+    assert.strictEqual(published.car_checksum, measurementRecorded.carChecksum)
+    assert.strictEqual(published.indexer_result, measurementRecorded.indexerResult)
     // TODO: test other fields
 
     // We are publishing records with invalid wallet addresses too
@@ -257,10 +261,12 @@ const insertMeasurement = async (client, measurement) => {
     attestation,
     inet_group,
     car_too_large,
+    car_checksum,
+    indexer_result,
     completed_at_round
   )
   VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
   )
 `, [
     measurement.sparkVersion,
@@ -278,6 +284,8 @@ const insertMeasurement = async (client, measurement) => {
     measurement.attestation,
     measurement.inetGroup,
     measurement.carTooLarge,
+    measurement.carChecksum,
+    measurement.indexerResult,
     measurement.round
   ])
 }

--- a/test/test.js
+++ b/test/test.js
@@ -133,7 +133,9 @@ describe('Routes', () => {
         endAt: new Date(),
         byteLength: 100,
         carTooLarge: true,
-        attestation: 'json.sig'
+        attestation: 'json.sig',
+        carChecksum: 'somehash',
+        indexerResult: 'OK'
       }
 
       const createRequest = await fetch(`${spark}/measurements`, {
@@ -175,6 +177,8 @@ describe('Routes', () => {
       assert.strictEqual(measurementRow.completed_at_round, currentSparkRoundNumber.toString())
       assert.match(measurementRow.inet_group, /^.{12}$/)
       assert.strictEqual(measurementRow.car_too_large, true)
+      assert.strictEqual(measurementRow.indexer_result, 'OK')
+      assert.strictEqual(measurementRow.car_checksum, 'somehash')
     })
 
     it('allows older format with walletAddress', async () => {


### PR DESCRIPTION
Modify spark-api and spark-publish to record two new measurement fields:
- `indexerResult`
- `carChecksum`

Links:
- https://github.com/filecoin-station/spark/issues/40
- https://github.com/filecoin-station/spark/issues/30
