### PR TITLE
ci: add send slack message on deployment failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,17 @@ jobs:
           cache-to: type=inline
 
   deploy-api:
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     needs: [build-api, build-publish, docker-build-api, docker-build-publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      - if: failure()
-        uses: slackapi/slack-github-action@v1.25.0
+      # - uses: actions/checkout@v4
+      # - uses: superfly/flyctl-actions/setup-flyctl@master
+      # - run: flyctl deploy --remote-only
+      #   env:
+      #     FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      # - if: failure()
+      - uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: filecoin-station-incidents
           slack-message: "${{ github.event.repository.name }} deployment failed!\n${{ github.event.head_commit.url }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,13 @@ jobs:
           channel-id: filecoin-station-incidents
           payload: |
             {
-              "text": "Deployment of `${{ github.event.repository.name }}` failed!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n${{ github.event.head_commit.url }}",
+              "text": "Deployment of `${{ github.event.repository.name }}` failed",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Deployment of `${{ github.event.repository.name }}` failed!\n- [Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n- [Commit](${{ github.event.head_commit.url }})"
+                    "text": "*Deployment of `${{ github.event.repository.name }}` failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Logs> | <${{ github.event.head_commit.url }}|Commit>"
                   }
                 }
               ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: filecoin-station-incidents
-          slack-message: "${{ github.event.repository.name }} deployment failed!\n${{ github.event.head_commit.url }}"
+          slack-message: "`${{ github.event.repository.name }}` deployment failed!\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   deploy-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,19 @@ jobs:
       - uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: filecoin-station-incidents
-          slack-message: "Deployment of `${{ github.event.repository.name }}` failed!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n${{ github.event.head_commit.url }}"
+          payload: |
+            {
+              "text": "Deployment of `${{ github.event.repository.name }}` failed!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n${{ github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Deployment of `${{ github.event.repository.name }}` failed!\n- [Logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n- [Commit](${{ github.event.head_commit.url }})"
+                  }
+                }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   deploy-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: filecoin-station-incidents
+          slack-message: "${{ github.event.repository.name }} deployment failed!\n${{ github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   deploy-publish:
     if: github.ref == 'refs/heads/main'
     needs: [build-api, build-publish, docker-build-api, docker-build-publish]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,17 @@ jobs:
           cache-to: type=inline
 
   deploy-api:
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: [build-api, build-publish, docker-build-api, docker-build-publish]
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v4
-      # - uses: superfly/flyctl-actions/setup-flyctl@master
-      # - run: flyctl deploy --remote-only
-      #   env:
-      #     FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      # - if: failure()
-      - uses: slackapi/slack-github-action@v1.25.0
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: filecoin-station-incidents
           payload: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: filecoin-station-incidents
-          slack-message: "`${{ github.event.repository.name }}` deployment failed!\n${{ github.event.head_commit.url }}"
+          slack-message: "Deployment of `${{ github.event.repository.name }}` failed!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n${{ github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   deploy-publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Deployment of `${{ github.event.repository.name }}` failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Logs> | <${{ github.event.head_commit.url }}|Commit>"
+                    "text": ":exclamation: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
                   }
                 }
               ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":exclamation: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
+                    "text": ":warning: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
                   }
                 }
               ]


### PR DESCRIPTION
For https://github.com/filecoin-station/roadmap/issues/69

<img width="289" alt="Screenshot 2024-02-09 at 09 02 51" src="https://github.com/filecoin-station/spark-api/assets/10247/f083eeae-b3de-459c-931a-b8c620bd0dbe">

Links to the workflow run, which itself has logs and links to the commit.