### PR TITLE
fix: 4x less tasks per round

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -8,10 +8,10 @@ import { createMeridianContract } from './ie-contract.js'
 // for more details, this constant represents TC (tasks per committee).
 //
 // We will need to tweak this value based on measurements; that's why I put it here as a constant.
-export const TASKS_PER_ROUND = 4000
+export const TASKS_PER_ROUND = 1000
 
 // How many tasks is each SPARK checker node expected to complete every round (at most).
-export const MAX_TASKS_PER_NODE = 60
+export const MAX_TASKS_PER_NODE = 15
 
 /**
  * @param {import('pg').Pool} pgPool

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -180,7 +180,7 @@ describe('Round Tracker', () => {
       assert.strictEqual(sparkRoundNumber, 1n)
       const sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
-      assert.strictEqual(sparkRounds[0].max_tasks_per_node, 60)
+      assert.strictEqual(sparkRounds[0].max_tasks_per_node, 15)
     })
   })
 })


### PR DESCRIPTION
spark-publish is not able to keep up with the number of measurements we are receiving. Let's reduce the number of tasks to allow the system to self-heal and give us more time to figure out how to scale this up.
