### PR TITLE
fix: allow measurements with no provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
   }
 
   validate(measurement, 'cid', { type: 'string', required: true })
-  validate(measurement, 'providerAddress', { type: 'string', required: true })
-  validate(measurement, 'protocol', { type: 'string', required: true })
+  validate(measurement, 'providerAddress', { type: 'string', required: false })
+  validate(measurement, 'protocol', { type: 'string', required: false })
   validate(measurement, 'participantAddress', { type: 'string', required: true })
   validate(measurement, 'timeout', { type: 'boolean', required: false })
   validate(measurement, 'startAt', { type: 'date', required: true })

--- a/migrations/043.do.measurements-without-provider.sql
+++ b/migrations/043.do.measurements-without-provider.sql
@@ -1,0 +1,5 @@
+ALTER TABLE measurements
+ALTER COLUMN provider_address DROP NOT NULL;
+
+ALTER TABLE measurements
+ALTER COLUMN protocol DROP NOT NULL;


### PR DESCRIPTION
We don't have the providerAddress & protocol fields for deals that are not advertised to IPNI.

This PR fixes a regression introduced by #209.

Links:
- https://www.notion.so/pl-strflt/Moving-IPNI-queries-to-Spark-checkers-c58175c0f1c841e6bb82ac44a1472a98
- https://github.com/filecoin-station/spark/issues/40

