### PR TITLE
feat: drop table `retrieval_templates`

### DIFF
--- a/migrations/044.do.drop-retrieval-templates.sql
+++ b/migrations/044.do.drop-retrieval-templates.sql
@@ -1,0 +1,1 @@
+DROP TABLE retrieval_templates;


### PR DESCRIPTION
We are using `retrievable_deals` for defining per-round tasks now.

Links:
- https://www.notion.so/pl-strflt/Moving-IPNI-queries-to-Spark-checkers-c58175c0f1c841e6bb82ac44a1472a98
- https://github.com/filecoin-station/spark/issues/40

