### PR TITLE
fix `cloudf{l}are` typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ export const inspectRequest = async (req, res) => {
   await json(res, {
     remoteAddress: req.socket.remoteAddress,
     flyClientAddr: req.headers['fly-client-ip'],
-    cloudfareAddr: req.headers['cf-connecting-ip'],
+    cloudflareAddr: req.headers['cf-connecting-ip'],
     forwardedFor: req.headers['x-forwarded-for'],
     headers: req.headersDistinct
   })


### PR DESCRIPTION
Discovered in https://github.com/filecoin-station/voyager/pull/3#discussion_r1513136835