### PR TITLE
feat: record & publish `minerId` and `providerId`

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
   validate(measurement, 'carTooLarge', { type: 'boolean', required: false })
   validate(measurement, 'carChecksum', { type: 'string', required: false })
   validate(measurement, 'indexerResult', { type: 'string', required: false })
+  validate(measurement, 'minerId', { type: 'string', required: false })
+  validate(measurement, 'providerId', { type: 'string', required: false })
 
   const inetGroup = await mapRequestToInetGroup(client, req)
 
@@ -87,10 +89,12 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
         car_too_large,
         car_checksum,
         indexer_result,
+        miner_id,
+        provider_id,
         completed_at_round
       )
       VALUES (
-        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
       )
       RETURNING id
     `, [
@@ -111,6 +115,8 @@ const createMeasurement = async (req, res, client, getCurrentRound) => {
     measurement.carTooLarge ?? false,
     measurement.carChecksum,
     measurement.indexerResult,
+    measurement.minerId,
+    measurement.providerId,
     sparkRoundNumber
   ])
   json(res, { id: rows[0].id })

--- a/migrations/047.do.measure-miner-provider.sql
+++ b/migrations/047.do.measure-miner-provider.sql
@@ -1,0 +1,5 @@
+ALTER TABLE measurements
+ADD COLUMN miner_id TEXT;
+
+ALTER TABLE measurements
+ADD COLUMN provider_id TEXT;

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -28,6 +28,8 @@ export const publish = async ({
       car_too_large,
       car_checksum,
       indexer_result,
+      miner_id,
+      provider_id,
       cid,
       provider_address,
       protocol

--- a/spark-publish/test/test.js
+++ b/spark-publish/test/test.js
@@ -125,6 +125,8 @@ describe('integration', () => {
       carTooLarge: true,
       carChecksum: 'somehash',
       indexerResult: 'ERROR_404',
+      minerId: 'f02abc',
+      providerId: 'provider-pubkey',
       round: 42
     }, {
       sparkVersion: '1.2.3',
@@ -142,6 +144,8 @@ describe('integration', () => {
       attestation: 'json.sig',
       inetGroup: 'MTIzNDU2Nzg',
       carTooLarge: true,
+      minerId: 'f02abc',
+      providerId: 'provider-pubkey',
       round: 42
     }]
 
@@ -228,6 +232,8 @@ describe('integration', () => {
     assert.strictEqual(published.end_at, null)
     assert.strictEqual(published.car_checksum, measurementRecorded.carChecksum)
     assert.strictEqual(published.indexer_result, measurementRecorded.indexerResult)
+    assert.strictEqual(published.miner_id, measurementRecorded.minerId)
+    assert.strictEqual(published.provider_id, measurementRecorded.providerId)
     // TODO: test other fields
 
     // We are publishing records with invalid wallet addresses too
@@ -263,10 +269,12 @@ const insertMeasurement = async (client, measurement) => {
     car_too_large,
     car_checksum,
     indexer_result,
+    miner_id,
+    provider_id,
     completed_at_round
   )
   VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
   )
 `, [
     measurement.sparkVersion,
@@ -286,6 +294,8 @@ const insertMeasurement = async (client, measurement) => {
     measurement.carTooLarge,
     measurement.carChecksum,
     measurement.indexerResult,
+    measurement.minerId,
+    measurement.providerId,
     measurement.round
   ])
 }

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,8 @@ const VALID_MEASUREMENT = {
   carTooLarge: true,
   attestation: 'json.sig',
   carChecksum: 'somehash',
+  minerId: 'f02abc',
+  providerId: 'provider-pubkey',
   indexerResult: 'OK'
 }
 
@@ -184,6 +186,8 @@ describe('Routes', () => {
       assert.strictEqual(measurementRow.car_too_large, true)
       assert.strictEqual(measurementRow.indexer_result, 'OK')
       assert.strictEqual(measurementRow.car_checksum, 'somehash')
+      assert.strictEqual(measurementRow.miner_id, measurement.minerId)
+      assert.strictEqual(measurementRow.provider_id, measurement.providerId)
     })
 
     it('allows older format with walletAddress', async () => {
@@ -323,6 +327,35 @@ describe('Routes', () => {
 
       assert.strictEqual(measurementRow.provider_address, null)
       assert.strictEqual(measurementRow.protocol, null)
+    })
+
+    it('allows no minerId/providerId', async () => {
+      await client.query('DELETE FROM measurements')
+
+      const measurement = {
+        ...VALID_MEASUREMENT,
+        minerId: undefined,
+        providerId: undefined
+      }
+
+      const createRequest = await fetch(`${spark}/measurements`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(measurement)
+      })
+      await assertResponseStatus(createRequest, 200)
+      const { id } = await createRequest.json()
+
+      const { rows: [measurementRow] } = await client.query(`
+          SELECT *
+          FROM measurements
+          WHERE id = $1
+        `, [
+        id
+      ])
+
+      assert.strictEqual(measurementRow.miner_id, null)
+      assert.strictEqual(measurementRow.provider_id, null)
     })
   })
 


### PR DESCRIPTION
- `minerId` is coming from the retrieval task as defined by spark-api

- `providerId` is resolved by checkers by calling JSON-RPC method `Filecoin.StateMinerInfo`

Links:
- https://github.com/filecoin-station/roadmap/issues/65
- [Miner to Provider ID mapper PoC](https://github.com/filecoin-station/fil-miner-retrieval-provider-id/blob/57496ea1e9db5997f6661bc6a768cbfa47d1404b/index.js)
