### PR TITLE
publish: set deploy strategy to rolling

### DIFF
--- a/spark-publish/fly.toml
+++ b/spark-publish/fly.toml
@@ -1,2 +1,4 @@
 app = "spark-publish"
 primary_region = "cdg"
+[deploy]
+  strategy = "rolling"


### PR DESCRIPTION
To ensure only one instance is running at a time