### PR TITLE
chore: enable Dependabot for spark-publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/spark-publish"
     schedule:
       interval: "daily"
       time: "09:00"


### PR DESCRIPTION
https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/
