### PR TITLE
deps: upgrade Node.js in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.8.1
+ARG NODE_VERSION=20.12.2
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="nodejs"

--- a/spark-publish/Dockerfile
+++ b/spark-publish/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.8.1
+ARG NODE_VERSION=20.12.2
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="nodejs"


### PR DESCRIPTION
It would be great to find a way how to automate this.
- Can Dependabot upgrade base image version for us?
- Alternatively, can we specify only the major version and let Docker pick the latest minor/patch version available at the time of building the image?
