### PR TITLE
chore: setup Dependabot for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,12 @@ updates:
     reviewers:
       - "bajtos"
       - "juliangruber"
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/spark-publish"
+    schedule:
+      interval: "daily"
+      time: "15:00"
+      timezone: "Europe/Berlin"
+


### PR DESCRIPTION
Per our discussion in https://github.com/filecoin-station/spark-api/pull/261
