### PR TITLE
feat: add "startEpoch" to round details

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,7 @@ const getMeridianRoundDetails = async (_req, res, client, meridianAddress, merid
   res.setHeader('cache-control', `public, max-age=${ONE_YEAR_IN_SECONDS}, immutable`)
   json(res, {
     roundId: round.id.toString(),
+    startEpoch: round.start_epoch,
     maxTasksPerNode: round.max_tasks_per_node,
     retrievalTasks: tasks.map(t => ({
       cid: t.cid,

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import Sentry from '@sentry/node'
 import { createMeridianContract } from './ie-contract.js'
 
@@ -30,12 +31,15 @@ export async function createRoundGetter (pgPool) {
     meridianRoundIndex = BigInt(newRoundIndex)
     meridianContractAddress = contract.address
 
+    const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
+
     const pgClient = await pgPool.connect()
     try {
       await pgClient.query('BEGIN')
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        roundStartEpoch,
         pgClient
       })
       await pgClient.query('COMMIT')
@@ -135,6 +139,7 @@ LIMIT 1
 export async function mapCurrentMeridianRoundToSparkRound ({
   meridianContractAddress,
   meridianRoundIndex,
+  roundStartEpoch,
   pgClient
 }) {
   let sparkRoundNumber
@@ -183,7 +188,12 @@ export async function mapCurrentMeridianRoundToSparkRound ({
     )
   }
 
-  await maybeCreateSparkRound(pgClient, { sparkRoundNumber, meridianContractAddress, meridianRoundIndex })
+  await maybeCreateSparkRound(pgClient, {
+    sparkRoundNumber,
+    meridianContractAddress,
+    meridianRoundIndex,
+    roundStartEpoch
+  })
 
   return sparkRoundNumber
 }
@@ -191,17 +201,19 @@ export async function mapCurrentMeridianRoundToSparkRound ({
 export async function maybeCreateSparkRound (pgClient, {
   sparkRoundNumber,
   meridianContractAddress,
-  meridianRoundIndex
+  meridianRoundIndex,
+  roundStartEpoch
 }) {
   const { rowCount } = await pgClient.query(`
     INSERT INTO spark_rounds
-    (id, created_at, meridian_address, meridian_round, max_tasks_per_node)
-    VALUES ($1, now(), $2, $3, $4)
+    (id, created_at, meridian_address, meridian_round, start_epoch, max_tasks_per_node)
+    VALUES ($1, now(), $2, $3, $4, $5)
     ON CONFLICT DO NOTHING
   `, [
     sparkRoundNumber,
     meridianContractAddress,
     meridianRoundIndex,
+    roundStartEpoch,
     MAX_TASKS_PER_NODE
   ])
 
@@ -224,4 +236,28 @@ async function defineTasksForRound (pgClient, sparkRoundNumber) {
     sparkRoundNumber,
     TASKS_PER_ROUND
   ])
+}
+
+/**
+ * @param {Awaited<ReturnType<import('./ie-contract.js').createMeridianContract>>} contract
+ * @param {bigint} roundIndex
+ * @returns {Promise<biging>} Filecoin Epoch (ETH block number) when the SPARK round started
+ */
+export async function getRoundStartEpoch (contract, roundIndex) {
+  assert.strictEqual(typeof roundIndex, 'bigint', `roundIndex must be a bigint, received: ${typeof roundIndex}`)
+
+  // Look at the last 1000 blocks to handle the case when we have an outage and
+  // the rounds are not advanced frequently enough.
+  const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -1000))
+    .map(({ blockNumber, args }) => ({ blockNumber, roundIndex: args[0].toBigInt() }))
+
+  const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)
+  if (!roundStart) {
+    throw Object.assign(
+      new Error(`Cannot find RoundStart event for round index ${roundIndex}`),
+      { roundIndex, recentRoundStartEvents }
+    )
+  }
+
+  return roundStart.blockNumber
 }

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -241,7 +241,7 @@ async function defineTasksForRound (pgClient, sparkRoundNumber) {
 /**
  * @param {Awaited<ReturnType<import('./ie-contract.js').createMeridianContract>>} contract
  * @param {bigint} roundIndex
- * @returns {Promise<biging>} Filecoin Epoch (ETH block number) when the SPARK round started
+ * @returns {Promise<bigint>} Filecoin Epoch (ETH block number) when the SPARK round started
  */
 export async function getRoundStartEpoch (contract, roundIndex) {
   assert.strictEqual(typeof roundIndex, 'bigint', `roundIndex must be a bigint, received: ${typeof roundIndex}`)

--- a/migrations/049.do.round-start-epoch.sql
+++ b/migrations/049.do.round-start-epoch.sql
@@ -4,4 +4,4 @@ ADD COLUMN start_epoch BIGINT;
 UPDATE spark_rounds SET start_epoch = 0;
 
 ALTER TABLE spark_rounds
-ALTER COLUMN start_epoch DROP NOT NULL;
+ALTER COLUMN start_epoch SET NOT NULL;

--- a/migrations/049.do.round-start-epoch.sql
+++ b/migrations/049.do.round-start-epoch.sql
@@ -1,0 +1,7 @@
+ALTER TABLE spark_rounds
+ADD COLUMN start_epoch BIGINT;
+
+UPDATE spark_rounds SET start_epoch = 0;
+
+ALTER TABLE spark_rounds
+ALTER COLUMN start_epoch DROP NOT NULL;

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -30,7 +30,7 @@ describe('Round Tracker', () => {
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 120n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -46,7 +46,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 121n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 2n)
@@ -65,7 +65,7 @@ describe('Round Tracker', () => {
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 120n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -74,7 +74,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1b',
         meridianRoundIndex: 10n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 2n)
@@ -91,7 +91,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1b',
         meridianRoundIndex: 11n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 3n)
@@ -108,12 +108,12 @@ describe('Round Tracker', () => {
       const now = new Date()
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
-      const sparkStartEpoch = 321n
+      const roundStartEpoch = 321n
 
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
-        sparkStartEpoch,
+        roundStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -126,7 +126,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
-        sparkStartEpoch,
+        roundStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -141,7 +141,7 @@ describe('Round Tracker', () => {
       const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 1n,
-        sparkStartEpoch: 321n,
+        roundStartEpoch: 321n,
         pgClient
       })
 
@@ -160,18 +160,18 @@ describe('Round Tracker', () => {
     it('creates tasks only once per round', async () => {
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
-      const sparkStartEpoch = 321n
+      const roundStartEpoch = 321n
 
       const firstRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
-        sparkStartEpoch,
+        roundStartEpoch,
         pgClient
       })
       const secondRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
-        sparkStartEpoch,
+        roundStartEpoch,
         pgClient
       })
       assert.strictEqual(firstRoundNumber, secondRoundNumber)
@@ -186,12 +186,12 @@ describe('Round Tracker', () => {
     it('sets tasks_per_round', async () => {
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
-      const sparkStartEpoch = 321n
+      const roundStartEpoch = 321n
 
       const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
-        sparkStartEpoch,
+        roundStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)

--- a/test/round-tracker.test.js
+++ b/test/round-tracker.test.js
@@ -30,6 +30,7 @@ describe('Round Tracker', () => {
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 120n,
+        sparkStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -45,6 +46,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 121n,
+        sparkStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 2n)
@@ -63,6 +65,7 @@ describe('Round Tracker', () => {
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 120n,
+        sparkStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -71,6 +74,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1b',
         meridianRoundIndex: 10n,
+        sparkStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 2n)
@@ -87,6 +91,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1b',
         meridianRoundIndex: 11n,
+        sparkStartEpoch: 321n,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 3n)
@@ -103,10 +108,12 @@ describe('Round Tracker', () => {
       const now = new Date()
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
+      const sparkStartEpoch = 321n
 
       let sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        sparkStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -119,6 +126,7 @@ describe('Round Tracker', () => {
       sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        sparkStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)
@@ -133,6 +141,7 @@ describe('Round Tracker', () => {
       const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress: '0x1a',
         meridianRoundIndex: 1n,
+        sparkStartEpoch: 321n,
         pgClient
       })
 
@@ -151,14 +160,18 @@ describe('Round Tracker', () => {
     it('creates tasks only once per round', async () => {
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
+      const sparkStartEpoch = 321n
+
       const firstRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        sparkStartEpoch,
         pgClient
       })
       const secondRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        sparkStartEpoch,
         pgClient
       })
       assert.strictEqual(firstRoundNumber, secondRoundNumber)
@@ -173,10 +186,12 @@ describe('Round Tracker', () => {
     it('sets tasks_per_round', async () => {
       const meridianRoundIndex = 1n
       const meridianContractAddress = '0x1a'
+      const sparkStartEpoch = 321n
 
       const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
+        sparkStartEpoch,
         pgClient
       })
       assert.strictEqual(sparkRoundNumber, 1n)

--- a/test/test.js
+++ b/test/test.js
@@ -58,7 +58,8 @@ describe('Routes', () => {
     await maybeCreateSparkRound(client, {
       sparkRoundNumber: currentSparkRoundNumber,
       meridianContractAddress: '0x1a',
-      meridianRoundIndex: 123n
+      meridianRoundIndex: 123n,
+      roundStartEpoch: 321n
     })
     const handler = await createHandler({
       client,
@@ -465,7 +466,8 @@ describe('Routes', () => {
       let num = await mapCurrentMeridianRoundToSparkRound({
         pgClient: client,
         meridianContractAddress: '0xOLD',
-        meridianRoundIndex: 10n
+        meridianRoundIndex: 10n,
+        roundStartEpoch: 321n
       })
       assert.strictEqual(num, 1n)
 
@@ -473,7 +475,8 @@ describe('Routes', () => {
       num = await mapCurrentMeridianRoundToSparkRound({
         pgClient: client,
         meridianContractAddress: '0xNEW',
-        meridianRoundIndex: 120n
+        meridianRoundIndex: 120n,
+        roundStartEpoch: 621n
       })
       assert.strictEqual(num, 2n)
 
@@ -481,7 +484,8 @@ describe('Routes', () => {
       num = await mapCurrentMeridianRoundToSparkRound({
         pgClient: client,
         meridianContractAddress: '0xNEW',
-        meridianRoundIndex: 121n
+        meridianRoundIndex: 121n,
+        roundStartEpoch: 921n
       })
       assert.strictEqual(num, 3n)
     })
@@ -493,7 +497,8 @@ describe('Routes', () => {
 
       assert.deepStrictEqual(details, {
         roundId: '2',
-        maxTasksPerNode: MAX_TASKS_PER_NODE
+        maxTasksPerNode: MAX_TASKS_PER_NODE,
+        startEpoch: '621'
       })
       assert.strictEqual(retrievalTasks.length, TASKS_PER_ROUND)
 
@@ -510,7 +515,8 @@ describe('Routes', () => {
 
       assert.deepStrictEqual(details, {
         roundId: '1',
-        maxTasksPerNode: MAX_TASKS_PER_NODE
+        maxTasksPerNode: MAX_TASKS_PER_NODE,
+        startEpoch: '321'
       })
       assert.strictEqual(retrievalTasks.length, TASKS_PER_ROUND)
     })
@@ -533,7 +539,8 @@ describe('Routes', () => {
       await maybeCreateSparkRound(client, {
         sparkRoundNumber: currentSparkRoundNumber,
         meridianContractAddress: '0x1a',
-        meridianRoundIndex: 123n
+        meridianRoundIndex: 123n,
+        roundStartEpoch: 321n
       })
     })
 
@@ -551,10 +558,12 @@ describe('Routes', () => {
 
       assert.deepStrictEqual(Object.keys(body), [
         'roundId',
+        'startEpoch',
         'maxTasksPerNode',
         'retrievalTasks'
       ])
       assert.strictEqual(body.roundId, currentSparkRoundNumber.toString())
+      assert.strictEqual(body.startEpoch, '321')
 
       for (const t of body.retrievalTasks) {
         assert.strictEqual(typeof t.cid, 'string')
@@ -571,7 +580,8 @@ describe('Routes', () => {
       await maybeCreateSparkRound(client, {
         sparkRoundNumber: currentSparkRoundNumber,
         meridianContractAddress: '0x1a',
-        meridianRoundIndex: 123n
+        meridianRoundIndex: 123n,
+        roundStartEpoch: 321n
       })
     })
 


### PR DESCRIPTION
In order to map SPARK rounds to DRAND randomness values, we need to know the epoch (block number) when the SPARK round started.

This pull request modifies the round tracker to query the start epoch and store in the database, and the REST API to include this new field in the round details responses.

Links:
- https://github.com/filecoin-station/spark/issues/27
- https://www.notion.so/pl-strflt/SPARK-tasking-v2-604e26d57f6b4892946525bcb3a77104#8fe99341a9a447b98f198021d536cc05
