### PR TITLE
feat: timeout & retry while waiting for FEVM tx

### DIFF
--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -66,10 +66,15 @@ export const publish = async ({
   start = new Date()
   const tx = await ieContract.addMeasurements(cid.toString())
   logger.log('Waiting for the transaction receipt:', tx.hash)
-  const receipt = await pRetry(() => tx.wait(1 /* confirmation(s) */, 120_000 /* 2 minutes */), {
-    onFailedAttempt: err => console.error(err),
-    maxRetryTime: 600_000 // 10-minute timeout
-  })
+  const receipt = await pRetry(
+    () => tx.wait(
+      1, // confirmation(s)
+      120_000 // 2 minutes
+    ), {
+      onFailedAttempt: err => console.error(err),
+      maxRetryTime: 600_000 // 10-minute timeout
+    }
+  )
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]
   const ieAddMeasurementsDuration = new Date() - start

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -1,5 +1,6 @@
 /* global File */
 
+import pRetry from 'p-retry'
 import { record } from './lib/telemetry.js'
 
 export const publish = async ({
@@ -65,7 +66,10 @@ export const publish = async ({
   start = new Date()
   const tx = await ieContract.addMeasurements(cid.toString())
   logger.log('Waiting for the transaction receipt:', tx.hash)
-  const receipt = await tx.wait()
+  const receipt = await pRetry(() => tx.wait(1 /* confirmation(s) */, 120_000 /* 2 minutes */), {
+    onFailedAttempt: err => console.error(err),
+    maxRetryTime: 600_000 // 10-minute timeout
+  })
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]
   const ieAddMeasurementsDuration = new Date() - start

--- a/spark-publish/package-lock.json
+++ b/spark-publish/package-lock.json
@@ -14,6 +14,7 @@
         "@web3-storage/access": "^18.3.2",
         "@web3-storage/w3up-client": "^11.0.2",
         "ethers": "^6.10.0",
+        "p-retry": "^6.2.0",
         "pg": "^8.11.3"
       },
       "devDependencies": {
@@ -1323,9 +1324,9 @@
       }
     },
     "node_modules/@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "node_modules/@ucanto/client": {
       "version": "9.0.1",
@@ -1708,6 +1709,11 @@
         "varint": "^6.0.0"
       }
     },
+    "node_modules/@web3-storage/upload-client/node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
     "node_modules/@web3-storage/upload-client/node_modules/multiformats": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
@@ -1715,6 +1721,21 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@web3-storage/upload-client/node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@web3-storage/w3up-client": {
@@ -4057,6 +4078,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5225,15 +5257,16 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
       "dependencies": {
-        "@types/retry": "0.12.1",
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/spark-publish/package.json
+++ b/spark-publish/package.json
@@ -14,6 +14,7 @@
     "@web3-storage/access": "^18.3.2",
     "@web3-storage/w3up-client": "^11.0.2",
     "ethers": "^6.10.0",
+    "p-retry": "^6.2.0",
     "pg": "^8.11.3"
   },
   "devDependencies": {


### PR DESCRIPTION
When waiting for confirmation of the `ie.addMeasurements()` transaction, implement a timeout of 2 minutes and retry scheme timing out after 10 minutes in total.

The goal is to prevent spark-publish from hanging indefinitely when the RPC API or the blockchain are not able to provide any confirmations.

Based on `add_measurements_duration_ms` collected in InfluxDB, most transactions are confirmed within 100 seconds, which is within the 2 minute timeout. There are occassional outliers going up to 500 seconds, they will be handled by the retries. We cannot afford to wait for the confirmation too long, otherwise we will not commit measurements before the round ends.
