### PR TITLE
perf: bring back index `measurements.published_at`

### DIFF
--- a/migrations/050.do.index-measurements-by-time.sql
+++ b/migrations/050.do.index-measurements-by-time.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY measurements_finished_at ON measurements (finished_at);


### PR DESCRIPTION
Apply https://github.com/filecoin-station/voyager-api/pull/29 from voyager-api.

Our observability tooling needs to find the oldest measurement, which is expensive to do without an index.
