### PR TITLE
fix: tweak retrying of `tx.wait()`

### DIFF
--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -73,7 +73,8 @@ export const publish = async ({
     ), {
       onFailedAttempt: err => console.error(err),
       shouldRetry: err => err.code !== 'CALL_EXCEPTION',
-      maxRetryTime: 600_000 // 10-minute timeout
+      signal: AbortSignal.timeout(600_000), // 10-minute timeout
+      retries: 5 // 5 * 2 minutes = 10 minutes - another measure to enforce ~10-minute timeout
     }
   )
   const log = ieContract.interface.parseLog(receipt.logs[0])

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -72,6 +72,7 @@ export const publish = async ({
       120_000 // 2 minutes
     ), {
       onFailedAttempt: err => console.error(err),
+      shouldRetry: err => err.code !== 'CALL_EXCEPTION',
       maxRetryTime: 600_000 // 10-minute timeout
     }
   )


### PR DESCRIPTION
- **fix: don't retry tx wait on CALL_EXCEPTION errors**
- **fix: retry timeout for `tx.wait()`**
