### PR TITLE
fix: search RoundStart events only ~2h in the past

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -246,9 +246,9 @@ async function defineTasksForRound (pgClient, sparkRoundNumber) {
 export async function getRoundStartEpoch (contract, roundIndex) {
   assert.strictEqual(typeof roundIndex, 'bigint', `roundIndex must be a bigint, received: ${typeof roundIndex}`)
 
-  // Look at the last 1000 blocks to handle the case when we have an outage and
+  // Look at the last 250 blocks (~2 hours) to handle the case when we have an outage and
   // the rounds are not advanced frequently enough.
-  const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -1000))
+  const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -250))
     .map(({ blockNumber, args }) => ({ blockNumber, roundIndex: args[0].toBigInt() }))
 
   const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)


### PR DESCRIPTION
I am trying the make the RPC API call easier to fulfill and thus return in the current timeout of 2 minutes even when Glif is under heavy load.
