### PR TITLE
feat: allow no roundStartEpoch for existing rounds

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -31,7 +31,7 @@ export async function createRoundGetter (pgPool) {
     meridianRoundIndex = BigInt(newRoundIndex)
     meridianContractAddress = contract.address
 
-    const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
+    const roundStartEpoch = await tryGetRoundStartEpoch(contract, meridianRoundIndex)
 
     const pgClient = await pgPool.connect()
     try {
@@ -204,6 +204,18 @@ export async function maybeCreateSparkRound (pgClient, {
   meridianRoundIndex,
   roundStartEpoch
 }) {
+  // Handle the case when we are not able to query the chain to obtain current round's start epoch
+  if (!roundStartEpoch) {
+    const { rowCount } = await pgClient.query(
+      'SELECT 1 FROM spark_rounds WHERE id = $1',
+      [sparkRoundNumber]
+    )
+    if (rowCount) return
+    throw new Error(
+      `Cannot initialize Spark round ${sparkRoundNumber}: roundStartEpoch was not provided.`
+    )
+  }
+
   const { rowCount } = await pgClient.query(`
     INSERT INTO spark_rounds
     (id, created_at, meridian_address, meridian_round, start_epoch, max_tasks_per_node)
@@ -241,23 +253,39 @@ async function defineTasksForRound (pgClient, sparkRoundNumber) {
 /**
  * @param {Awaited<ReturnType<import('./ie-contract.js').createMeridianContract>>} contract
  * @param {bigint} roundIndex
- * @returns {Promise<bigint>} Filecoin Epoch (ETH block number) when the SPARK round started
- */
-export async function getRoundStartEpoch (contract, roundIndex) {
+ * @param {Console} [logger]
+ * @returns {Promise<bigint | undefined>} Filecoin Epoch (ETH block number) when the SPARK round started.
+ * Returns `undefined` if the round started too long ago or the RPC API call timed out.
+*/
+export async function tryGetRoundStartEpoch (contract, roundIndex, logger = console) {
   assert.strictEqual(typeof roundIndex, 'bigint', `roundIndex must be a bigint, received: ${typeof roundIndex}`)
 
-  // Look at the last 1000 blocks to handle the case when we have an outage and
-  // the rounds are not advanced frequently enough.
-  const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -1000))
-    .map(({ blockNumber, args }) => ({ blockNumber, roundIndex: args[0].toBigInt() }))
+  try {
+    // Look at the last 250 blocks (~2 hours) to handle the case when we have an outage and
+    // the rounds are not advanced frequently enough.
+    const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -250))
+      .map(({ blockNumber, args }) => ({ blockNumber, roundIndex: args[0].toBigInt() }))
 
-  const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)
-  if (!roundStart) {
-    throw Object.assign(
-      new Error(`Cannot find RoundStart event for round index ${roundIndex}`),
-      { roundIndex, recentRoundStartEvents }
-    )
+    const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)
+    if (!roundStart) {
+      logger.error(`
+Cannot find RoundStart event for round index ${roundIndex}.
+Assuming the round started long time ago and we already track it in Spark DB.
+Recent events:`.trim(),
+      recentRoundStartEvents
+      )
+      return undefined
+    }
+
+    return roundStart.blockNumber
+  } catch (err) {
+    if (err.code === 'TIMEOUT') {
+      logger.error(
+        'RoundStart query timed out. Hoping the round is already tracked in Spark DB.',
+        err
+      )
+      return undefined
+    }
+    throw err
   }
-
-  return roundStart.blockNumber
 }


### PR DESCRIPTION
When the Glif RPC API calls are timing out, or when our system is broken and rounds are not advancing at all, allow the spark-api service to start, even though it cannot obtain the roundStartEpoch of the current round.
