### PR TITLE
feat: decouple round tracker from API routes

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -58,9 +58,10 @@ client.on('error', err => {
 })
 await migrate(client)
 
+console.log('Initializing round tracker...')
+const start = Date.now()
+
 try {
-  console.log('Initializing round tracker...')
-  const start = Date.now()
   const currentRound = await startRoundTracker(client)
   console.log(
     'Initialized round tracker in %sms. SPARK round number at service startup: %s',

--- a/bin/spark.js
+++ b/bin/spark.js
@@ -6,9 +6,8 @@ import Sentry from '@sentry/node'
 import fs from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { createRoundGetter } from '../lib/round-tracker.js'
+import { startRoundTracker } from '../lib/round-tracker.js'
 import { migrate } from '../lib/migrate.js'
-import assert from 'node:assert'
 
 const {
   PORT = 8080,
@@ -59,11 +58,19 @@ client.on('error', err => {
 })
 await migrate(client)
 
-const getCurrentRound = await createRoundGetter(client)
-
-const round = getCurrentRound()
-assert(!!round, 'cannot obtain the current Spark round number')
-console.log('SPARK round number at service startup:', round.sparkRoundNumber)
+try {
+  console.log('Initializing round tracker...')
+  const start = Date.now()
+  const currentRound = await startRoundTracker(client)
+  console.log(
+    'Initialized round tracker in %sms. SPARK round number at service startup: %s',
+    Date.now() - start,
+    currentRound.sparkRoundNumber
+  )
+} catch (err) {
+  console.error('Cannot obtain the current Spark round number:', err)
+  process.exit(1)
+}
 
 const logger = {
   error: console.error,
@@ -74,7 +81,6 @@ const logger = {
 const handler = await createHandler({
   client,
   logger,
-  getCurrentRound,
   domain: DOMAIN
 })
 const server = http.createServer(handler)

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const getMeasurement = async (req, res, client, measurementId) => {
 const getRoundDetails = async (req, res, client, roundParam) => {
   if (roundParam === 'current') {
     const { rows: [round] } = await client.query(`
-      SELECT meridianContractAddress, meridianRoundIndex FROM spark_rounds
+      SELECT meridian_address, meridian_round FROM spark_rounds
       ORDER BY id DESC
       LIMIT 1
     `)

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -16,36 +16,42 @@ export const MAX_TASKS_PER_NODE = 15
 
 /**
  * @param {import('pg').Pool} pgPool
- * @returns {() => {
+ * @returns {
  *  sparkRoundNumber: bigint;
  *  meridianContractAddress: string;
  *  meridianRoundIndex: bigint;
- * }}
+ *  roundStartEpoch: bigint;
+ * }
  */
-export async function createRoundGetter (pgPool) {
+export async function startRoundTracker (pgPool) {
   const contract = await createMeridianContract()
 
-  let sparkRoundNumber, meridianContractAddress, meridianRoundIndex
-
   const updateSparkRound = async (newRoundIndex) => {
-    meridianRoundIndex = BigInt(newRoundIndex)
-    meridianContractAddress = contract.address
+    const meridianRoundIndex = BigInt(newRoundIndex)
+    const meridianContractAddress = contract.address
 
     const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
 
     const pgClient = await pgPool.connect()
     try {
       await pgClient.query('BEGIN')
-      sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
+      const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
         meridianContractAddress,
         meridianRoundIndex,
         roundStartEpoch,
         pgClient
       })
       await pgClient.query('COMMIT')
-      console.log('SPARK round started: %s', sparkRoundNumber)
+      console.log('SPARK round started: %s (epoch: %s)', sparkRoundNumber, roundStartEpoch)
+      return {
+        sparkRoundNumber,
+        meridianContractAddress,
+        meridianRoundIndex,
+        roundStartEpoch
+      }
     } catch (err) {
       await pgClient.query('ROLLBACK')
+      throw err
     } finally {
       pgClient.release()
     }
@@ -58,13 +64,8 @@ export async function createRoundGetter (pgPool) {
     })
   })
 
-  await updateSparkRound(await contract.currentRoundIndex())
-
-  return () => ({
-    sparkRoundNumber,
-    meridianContractAddress,
-    meridianRoundIndex
-  })
+  const currentRound = await updateSparkRound(await contract.currentRoundIndex())
+  return currentRound
 }
 
 /*

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import { createHandler } from '../index.js'
+import { createHandler, getCurrentRound } from '../index.js'
 import http from 'node:http'
 import { once } from 'node:events'
 import assert, { AssertionError } from 'node:assert'
@@ -68,13 +68,6 @@ describe('Routes', () => {
         error: console.error,
         request () {}
       },
-      getCurrentRound () {
-        return {
-          sparkRoundNumber: currentSparkRoundNumber,
-          meridianContractAddress: '0x1a',
-          meridianRoundIndex: 123n
-        }
-      },
       domain: '127.0.0.1'
     })
     server = http.createServer(handler)
@@ -87,6 +80,17 @@ describe('Routes', () => {
     server.closeAllConnections()
     server.close()
     await client.end()
+  })
+
+  describe('getCurrentRound', () => {
+    it('returns expected round details from database', async () => {
+      const round = await getCurrentRound(client)
+      assert.deepStrictEqual(round, {
+        sparkRoundNumber: currentSparkRoundNumber,
+        meridianContractAddress: '0x1a',
+        meridianRoundIndex: 123n
+      })
+    })
   })
 
   describe('GET /', () => {
@@ -629,13 +633,6 @@ describe('Routes', () => {
             info () {},
             error: console.error,
             request () {}
-          },
-          getCurrentRound () {
-            return {
-              sparkRoundNumber: currentSparkRoundNumber,
-              meridianContractAddress: '0x1a',
-              meridianRoundIndex: 123n
-            }
           },
           domain: 'foobar'
         })

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import { createHandler, getCurrentRound } from '../index.js'
+import { createHandler } from '../index.js'
 import http from 'node:http'
 import { once } from 'node:events'
 import assert, { AssertionError } from 'node:assert'
@@ -80,17 +80,6 @@ describe('Routes', () => {
     server.closeAllConnections()
     server.close()
     await client.end()
-  })
-
-  describe('getCurrentRound', () => {
-    it('returns expected round details from database', async () => {
-      const round = await getCurrentRound(client)
-      assert.deepStrictEqual(round, {
-        sparkRoundNumber: currentSparkRoundNumber,
-        meridianContractAddress: '0x1a',
-        meridianRoundIndex: 123n
-      })
-    })
   })
 
   describe('GET /', () => {


### PR DESCRIPTION
**feat: decouple round tracker from API routes**

Rework API handlers to get the current round from the database.

Benefits:

- This commit fixes the long-standing bug where the REST API returned different current round depending on which worker process received the request. This was caused by different timing when each worker process detected a new RoundStarted event.

- The new architecture allows us to further decouple the round tracker from the API handler. We can run it in background to not block process startup or even extract it into a standalone service.

Downsides:

- More database queries. Before my changes, the current round was available in memory. Now we need to read it from the database.  Affected endpoints:
  - `POST /measurements`
  - `GET /rounds/current`

Note: The next commit reworks the query recording a new measurement to obtain the current round number in a sub-query of the `INSERT` statement.

**perf: inline `getCurrentRound()`**

- Rework the query inserting new measurements to fetch the current round as part of the single INSERT statement.

- Inline `getCurrentRound()` implementation into the single remaining place calling it - the handler for `GET /rounds/current`.
