### PR TITLE
fix: timeout for the entire smart-contract call

### DIFF
--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -64,7 +64,7 @@ export const publish = async ({
 
   // Call contract with CID
   const signal = AbortSignal.timeout(600_000) // 10-minute timeout
-  const { roundIndex, ieAddMeasurementsDuration } = pTimeout(
+  const { roundIndex, ieAddMeasurementsDuration } = await pTimeout(
     commitMeasurements({ cid, ieContract, logger, signal }),
     { signal, milliseconds: Number.POSITIVE_INFINITY /* timeout is triggered by signal */ }
   )

--- a/spark-publish/index.js
+++ b/spark-publish/index.js
@@ -66,7 +66,7 @@ export const publish = async ({
   const signal = AbortSignal.timeout(600_000) // 10-minute timeout
   const { roundIndex, ieAddMeasurementsDuration } = pTimeout(
     commitMeasurements({ cid, ieContract, logger, signal }),
-    { signal }
+    { signal, milliseconds: Number.POSITIVE_INFINITY /* timeout is triggered by signal */ }
   )
 
   const pgClient = await pgPool.connect()

--- a/spark-publish/package-lock.json
+++ b/spark-publish/package-lock.json
@@ -21,6 +21,7 @@
         "@flydotio/dockerfile": "^0.5.7",
         "mocha": "^10.4.0",
         "multiformats": "^13.1.0",
+        "p-timeout": "^6.1.2",
         "standard": "^17.1.0"
       }
     },
@@ -4372,6 +4373,18 @@
       },
       "engines": {
         "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/spark-publish/package.json
+++ b/spark-publish/package.json
@@ -21,6 +21,7 @@
     "@flydotio/dockerfile": "^0.5.7",
     "mocha": "^10.4.0",
     "multiformats": "^13.1.0",
+    "p-timeout": "^6.1.2",
     "standard": "^17.1.0"
   },
   "standard": {


### PR DESCRIPTION
I noticed that spark-publish got again stuck for more than an hour today, I had
to restart the machine to resume publishing.

```
2024-05-14T09:19:55Z app[6e82994bee5798] cdg [info]Invoking ie.addMeasurements()...
2024-05-14T09:19:58Z app[6e82994bee5798] cdg [info]Waiting for the transaction receipt: 0x62111d12b4a6b79abf05fd8a8b40dd7aefab51ead06f810988e1e1eebfdc86b7
2024-05-14T10:46:10Z app[6e82994bee5798] cdg [info] INFO Sending signal SIGINT to main child process w/ PID 306
```

In this pull request, I extracted the step "Call contract with CID" into
a standalone function and wrapped the function call in `pTimeout`.
