### PR TITLE
refactor: use AbortSignal instead of `close()`

### DIFF
--- a/bin/spark.js
+++ b/bin/spark.js
@@ -40,7 +40,7 @@ console.log('Initializing round tracker...')
 const start = Date.now()
 
 try {
-  const currentRound = await startRoundTracker(client)
+  const currentRound = await startRoundTracker({ pgPool: client })
   console.log(
     'Initialized round tracker in %sms. SPARK round number at service startup: %s',
     Date.now() - start,

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -15,7 +15,9 @@ export const TASKS_PER_ROUND = 1000
 export const MAX_TASKS_PER_NODE = 15
 
 /**
- * @param {import('pg').Pool} pgPool
+ * @param {object} args
+ * @param {import('pg').Pool} args.pgPool
+ * @param {AbortSignal} [args.signal]
  * @returns {
  *  sparkRoundNumber: bigint;
  *  meridianContractAddress: string;
@@ -23,7 +25,7 @@ export const MAX_TASKS_PER_NODE = 15
  *  roundStartEpoch: bigint;
  * }
  */
-export async function startRoundTracker (pgPool) {
+export async function startRoundTracker ({ pgPool, signal }) {
   const contract = await createMeridianContract()
 
   const updateSparkRound = async (/** @type {bigint} */ newRoundIndex) => {
@@ -64,15 +66,14 @@ export async function startRoundTracker (pgPool) {
     })
   }
   contract.on('RoundStart', onRoundStart)
-  const close = () => contract.removeListener('RoundStart', onRoundStart)
-
-  try {
-    const currentRound = await updateSparkRound(await contract.currentRoundIndex())
-    return { ...currentRound, close }
-  } catch (err) {
-    close()
-    throw err
+  if (signal) {
+    signal.addEventListener('abort', () => {
+      contract.removeListener('RoundStart', onRoundStart)
+    })
   }
+
+  const currentRound = await updateSparkRound(await contract.currentRoundIndex())
+  return currentRound
 }
 
 /*


### PR DESCRIPTION
Refactor cancellation of the background task created by `startRoundTracker` to use injected AbortSignal instead of returning a `close()` function.
