### PR TITLE
fix: use polling for reading on-chain events

### DIFF
--- a/lib/ie-contract.js
+++ b/lib/ie-contract.js
@@ -3,7 +3,9 @@ import { IE_CONTRACT_ABI, IE_CONTRACT_ADDRESS, RPC_URL, GLIF_TOKEN } from '../sp
 
 const fetchRequest = new ethers.FetchRequest(RPC_URL)
 fetchRequest.setHeader('Authorization', `Bearer ${GLIF_TOKEN}`)
-const provider = new ethers.JsonRpcProvider(fetchRequest)
+const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
+  polling: true
+})
 
 // Uncomment for troubleshooting
 // provider.on('debug', d => console.log('[ethers:debug] %s\npayload: %o', d.action, d.payload))


### PR DESCRIPTION
Lotus does not support filters when using JSON-RPC, see https://github.com/filecoin-project/lotus/issues/11589

This PR supersedes #304
