### PR TITLE
fix: ethers provider debugging

### DIFF
--- a/lib/ie-contract.js
+++ b/lib/ie-contract.js
@@ -8,7 +8,7 @@ const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
 })
 
 // Uncomment for troubleshooting
-// provider.on('debug', d => console.log('[ethers:debug] %s %o', d.action, d.payload ?? d.result))
+// provider.on('debug', d => console.log('[ethers:debug %s] %s %o', new Date().toISOString().split('T')[1], d.action, d.payload ?? d.result))
 
 export const createMeridianContract = async () => new ethers.Contract(
   IE_CONTRACT_ADDRESS,

--- a/lib/ie-contract.js
+++ b/lib/ie-contract.js
@@ -8,7 +8,7 @@ const provider = new ethers.JsonRpcProvider(fetchRequest, undefined, {
 })
 
 // Uncomment for troubleshooting
-// provider.on('debug', d => console.log('[ethers:debug] %s\npayload: %o', d.action, d.payload))
+// provider.on('debug', d => console.log('[ethers:debug] %s %o', d.action, d.payload ?? d.result))
 
 export const createMeridianContract = async () => new ethers.Contract(
   IE_CONTRACT_ADDRESS,


### PR DESCRIPTION
The action `sendRpcPayload` includes `payload` property but the action `receiveRpcResult` includes `result` property instead.
