### PR TITLE
feat: get blockNumber from Ethers.js event data

### DIFF
--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -41,7 +41,7 @@ export async function startRoundTracker ({ pgPool, signal }) {
       )
     }
 
-    updateSparkRound(pgPool, contract, newRoundIndex, event.log.blockNumber).catch(err => {
+    updateSparkRound(pgPool, contract, newRoundIndex, blockNumber).catch(err => {
       console.error('Cannot handle RoundStart:', err)
       Sentry.captureException(err)
     })

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -30,8 +30,15 @@ export const MAX_TASKS_PER_NODE = 15
 export async function startRoundTracker ({ pgPool, signal }) {
   const contract = await createMeridianContract()
 
-  const onRoundStart = (newRoundIndex) => {
-    updateSparkRound(pgPool, contract, newRoundIndex).catch(err => {
+  const onRoundStart = (newRoundIndex, ...args) => {
+    /** @type {import('ethers').ContractEventPayload} */
+    const event = args.pop()
+    const blockNumber = event?.log?.blockNumber
+    if (blockNumber === undefined) {
+      console.warn('Ethers.js event data did not include ContractEvent with the block number')
+    }
+
+    updateSparkRound(pgPool, contract, newRoundIndex, event.log.blockNumber).catch(err => {
       console.error('Cannot handle RoundStart:', err)
       Sentry.captureException(err)
     })
@@ -51,13 +58,16 @@ export async function startRoundTracker ({ pgPool, signal }) {
  * @param {import('pg').Pool} pgPool
  * @param {MeridianContract} contract
  * @param {bigint} newRoundIndex
+ * @param {number} [roundStartEpoch]
  * @returns
  */
-async function updateSparkRound (pgPool, contract, newRoundIndex) {
+async function updateSparkRound (pgPool, contract, newRoundIndex, roundStartEpoch) {
   const meridianRoundIndex = BigInt(newRoundIndex)
   const meridianContractAddress = await contract.getAddress()
 
-  const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
+  if (roundStartEpoch === undefined) {
+    roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
+  }
 
   const pgClient = await pgPool.connect()
   try {

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -14,6 +14,8 @@ export const TASKS_PER_ROUND = 1000
 // How many tasks is each SPARK checker node expected to complete every round (at most).
 export const MAX_TASKS_PER_NODE = 15
 
+/** @typedef {Awaited<ReturnType<import('./ie-contract.js').createMeridianContract>>} MeridianContract */
+
 /**
  * @param {object} args
  * @param {import('pg').Pool} args.pgPool
@@ -28,39 +30,8 @@ export const MAX_TASKS_PER_NODE = 15
 export async function startRoundTracker ({ pgPool, signal }) {
   const contract = await createMeridianContract()
 
-  const updateSparkRound = async (/** @type {bigint} */ newRoundIndex) => {
-    const meridianRoundIndex = BigInt(newRoundIndex)
-    const meridianContractAddress = await contract.getAddress()
-
-    const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
-
-    const pgClient = await pgPool.connect()
-    try {
-      await pgClient.query('BEGIN')
-      const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
-        meridianContractAddress,
-        meridianRoundIndex,
-        roundStartEpoch,
-        pgClient
-      })
-      await pgClient.query('COMMIT')
-      console.log('SPARK round started: %s (epoch: %s)', sparkRoundNumber, roundStartEpoch)
-      return {
-        sparkRoundNumber,
-        meridianContractAddress,
-        meridianRoundIndex,
-        roundStartEpoch
-      }
-    } catch (err) {
-      await pgClient.query('ROLLBACK')
-      throw err
-    } finally {
-      pgClient.release()
-    }
-  }
-
   const onRoundStart = (newRoundIndex) => {
-    updateSparkRound(newRoundIndex).catch(err => {
+    updateSparkRound(pgPool, contract, newRoundIndex).catch(err => {
       console.error('Cannot handle RoundStart:', err)
       Sentry.captureException(err)
     })
@@ -72,8 +43,45 @@ export async function startRoundTracker ({ pgPool, signal }) {
     })
   }
 
-  const currentRound = await updateSparkRound(await contract.currentRoundIndex())
+  const currentRound = await updateSparkRound(pgPool, contract, await contract.currentRoundIndex())
   return currentRound
+}
+
+/**
+ * @param {import('pg').Pool} pgPool
+ * @param {MeridianContract} contract
+ * @param {bigint} newRoundIndex
+ * @returns
+ */
+async function updateSparkRound (pgPool, contract, newRoundIndex) {
+  const meridianRoundIndex = BigInt(newRoundIndex)
+  const meridianContractAddress = await contract.getAddress()
+
+  const roundStartEpoch = await getRoundStartEpoch(contract, meridianRoundIndex)
+
+  const pgClient = await pgPool.connect()
+  try {
+    await pgClient.query('BEGIN')
+    const sparkRoundNumber = await mapCurrentMeridianRoundToSparkRound({
+      meridianContractAddress,
+      meridianRoundIndex,
+      roundStartEpoch,
+      pgClient
+    })
+    await pgClient.query('COMMIT')
+    console.log('SPARK round started: %s (epoch: %s)', sparkRoundNumber, roundStartEpoch)
+    return {
+      sparkRoundNumber,
+      meridianContractAddress,
+      meridianRoundIndex,
+      roundStartEpoch
+    }
+  } catch (err) {
+    await pgClient.query('ROLLBACK')
+    throw err
+  } finally {
+    pgClient.release()
+  }
 }
 
 /*
@@ -248,7 +256,7 @@ async function defineTasksForRound (pgClient, sparkRoundNumber) {
 }
 
 /**
- * @param {Awaited<ReturnType<import('./ie-contract.js').createMeridianContract>>} contract
+ * @param {MeridianContract} contract
  * @param {bigint} roundIndex
  * @returns {Promise<number>} Filecoin Epoch (ETH block number) when the SPARK round started
  */

--- a/lib/round-tracker.js
+++ b/lib/round-tracker.js
@@ -35,7 +35,10 @@ export async function startRoundTracker ({ pgPool, signal }) {
     const event = args.pop()
     const blockNumber = event?.log?.blockNumber
     if (blockNumber === undefined) {
-      console.warn('Ethers.js event data did not include ContractEvent with the block number')
+      console.warn(
+        'Ethers.js event data did not include ContractEventPayload with the block number. ' +
+        'Will call `eth_getLogs` to find the round start epoch.'
+      )
     }
 
     updateSparkRound(pgPool, contract, newRoundIndex, event.log.blockNumber).catch(err => {


### PR DESCRIPTION
I found a way how to access the ContractEventPayload from the contract event listener function. By getting the block number from the event data, we don't have to make another RPC call to find the block number via potentially expensive & slow `eth_getLogs`.

Very loosely related to:
- https://github.com/filecoin-station/spark-api/issues/311

