### PR TITLE
test: clean DB before testing retrievable_deals PK

### DIFF
--- a/test/db.test.js
+++ b/test/db.test.js
@@ -20,11 +20,14 @@ describe('spark-api database', () => {
   })
 
   it('allows multiple storage deals for the same CID', async () => {
+    const DUMMY_CID = 'bafyone'
+    await client.query('DELETE FROM retrievable_deals WHERE cid = $1', [DUMMY_CID])
+
     await client.query(`
       INSERT INTO retrievable_deals (cid, miner_id, expires_at)
       VALUES ($1, $2, $3), ($1, $4, $3)
     `, [
-      'bafyone',
+      DUMMY_CID,
       'f010',
       new Date(),
       'f020'


### PR DESCRIPTION
I noticed that subsequent runs of this test failed because the test
was trying to insert the same CID again.

    duplicate key value violates unique constraint "retrievable_deals_pkey"

This commit fixes the problem by modifying the test to remove dummy
deals created by previous runs.
