### PR TITLE
test(publish): use mocked telemetry recorder

### DIFF
--- a/publish/index.js
+++ b/publish/index.js
@@ -2,12 +2,12 @@
 
 import pRetry from 'p-retry'
 import pTimeout from 'p-timeout'
-import { record } from './lib/telemetry.js'
 
 export const publish = async ({
   client: pgPool,
   web3Storage,
   ieContract,
+  recordTelemetry,
   maxMeasurements = 1000,
   logger = console
 }) => {
@@ -110,7 +110,7 @@ export const publish = async ({
 
   logger.log('Done!')
 
-  record('publish', point => {
+  recordTelemetry('publish', point => {
     point.intField('round_index', roundIndex)
     point.intField('measurements', measurements.length)
     point.floatField('load', totalCount / maxMeasurements)

--- a/publish/lib/telemetry.js
+++ b/publish/lib/telemetry.js
@@ -15,10 +15,14 @@ setInterval(() => {
   writeClient.flush().catch(console.error)
 }, 10_000).unref()
 
-export const record = (name, fn) => {
+export const recordTelemetry = (name, fn) => {
   const point = new Point(name)
   fn(point)
   writeClient.writePoint(point)
 }
 
 export const close = () => writeClient.close()
+
+export {
+  Point
+}

--- a/publish/test/platform-test-helpers.js
+++ b/publish/test/platform-test-helpers.js
@@ -1,0 +1,32 @@
+// This file is shared with voyager-api/voyager-publish
+// Helpers in this file must not have anything project-specific like measurement fields
+
+import { Point } from '../lib/telemetry.js'
+
+export const { DATABASE_URL } = process.env
+
+export const logger = {
+  log () {},
+  error (...args) {
+    console.error(...args)
+  }
+}
+
+export const createTelemetryRecorderStub = () => {
+  /** @type {Point[]} */
+  const telemetry = []
+  /**
+   *
+   * @param {string} measurementName
+   * @param {(point: Point) => void} fn
+   */
+  const recordTelemetry = (measurementName, fn) => {
+    const point = new Point(measurementName)
+    fn(point)
+    // TODO
+    // debug('recordTelemetry(%s): %o', measurementName, point.fields)
+    telemetry.push(point)
+  }
+
+  return { recordTelemetry, telemetry }
+}

--- a/publish/test/test-helpers.js
+++ b/publish/test/test-helpers.js
@@ -1,0 +1,56 @@
+export * from './platform-test-helpers.js'
+
+/**
+ * @param {import('pg').Client} client
+ * @param {object} measurement
+ */
+export const insertMeasurement = async (client, measurement) => {
+  await client.query(`
+  INSERT INTO measurements (
+    spark_version,
+    zinnia_version,
+    cid,
+    provider_address,
+    protocol,
+    participant_address,
+    timeout,
+    start_at,
+    status_code,
+    first_byte_at,
+    end_at,
+    byte_length,
+    attestation,
+    inet_group,
+    car_too_large,
+    car_checksum,
+    indexer_result,
+    miner_id,
+    provider_id,
+    completed_at_round
+  )
+  VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+  )
+`, [
+    measurement.sparkVersion,
+    measurement.zinniaVersion,
+    measurement.cid,
+    measurement.providerAddress,
+    measurement.protocol,
+    measurement.participantAddress,
+    measurement.timeout,
+    measurement.startAt,
+    measurement.statusCode,
+    measurement.firstByteAt,
+    measurement.endAt,
+    measurement.byteLength,
+    measurement.attestation,
+    measurement.inetGroup,
+    measurement.carTooLarge,
+    measurement.carChecksum,
+    measurement.indexerResult,
+    measurement.minerId,
+    measurement.providerId,
+    measurement.round
+  ])
+}

--- a/publish/test/test-helpers.js
+++ b/publish/test/test-helpers.js
@@ -1,4 +1,5 @@
 export * from './platform-test-helpers.js'
+export * from '../../test-helpers/assert.js'
 
 /**
  * @param {import('pg').Client} client

--- a/publish/test/test.js
+++ b/publish/test/test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert'
 import { CID } from 'multiformats/cid'
 import pg from 'pg'
 
-import { assertApproximately } from '../../test-helpers/assert.js'
 import {
+  assertApproximately,
   DATABASE_URL,
   createTelemetryRecorderStub,
   insertMeasurement,

--- a/publish/test/test.js
+++ b/publish/test/test.js
@@ -2,13 +2,14 @@ import { publish } from '../index.js'
 import assert from 'node:assert'
 import { CID } from 'multiformats/cid'
 import pg from 'pg'
-import * as telemetry from '../lib/telemetry.js'
 
 import { assertApproximately } from '../../test-helpers/assert.js'
-
-const { DATABASE_URL } = process.env
-
-after(telemetry.close)
+import {
+  DATABASE_URL,
+  createTelemetryRecorderStub,
+  insertMeasurement,
+  logger
+} from './test-helpers.js'
 
 describe('unit', () => {
   it('publishes', async () => {
@@ -70,12 +71,13 @@ describe('unit', () => {
       }
     }
 
-    const logger = { log () {} }
+    const { recordTelemetry } = createTelemetryRecorderStub()
 
     await publish({
       client,
       web3Storage,
       ieContract,
+      recordTelemetry,
       maxMeasurements: 1,
       logger
     })
@@ -198,17 +200,13 @@ describe('integration', () => {
       }
     }
 
-    const logger = {
-      log () {},
-      error (...args) {
-        console.error(...args)
-      }
-    }
+    const { recordTelemetry } = createTelemetryRecorderStub()
 
     await publish({
       client,
       web3Storage,
       ieContract,
+      recordTelemetry,
       maxMeasurements: 2,
       logger
     })
@@ -248,54 +246,3 @@ describe('integration', () => {
     assert.deepStrictEqual(remainingMeasurements.map(r => r.cid), ['bafynew'])
   })
 })
-
-const insertMeasurement = async (client, measurement) => {
-  await client.query(`
-  INSERT INTO measurements (
-    spark_version,
-    zinnia_version,
-    cid,
-    provider_address,
-    protocol,
-    participant_address,
-    timeout,
-    start_at,
-    status_code,
-    first_byte_at,
-    end_at,
-    byte_length,
-    attestation,
-    inet_group,
-    car_too_large,
-    car_checksum,
-    indexer_result,
-    miner_id,
-    provider_id,
-    completed_at_round
-  )
-  VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
-  )
-`, [
-    measurement.sparkVersion,
-    measurement.zinniaVersion,
-    measurement.cid,
-    measurement.providerAddress,
-    measurement.protocol,
-    measurement.participantAddress,
-    measurement.timeout,
-    measurement.startAt,
-    measurement.statusCode,
-    measurement.firstByteAt,
-    measurement.endAt,
-    measurement.byteLength,
-    measurement.attestation,
-    measurement.inetGroup,
-    measurement.carTooLarge,
-    measurement.carChecksum,
-    measurement.indexerResult,
-    measurement.minerId,
-    measurement.providerId,
-    measurement.round
-  ])
-}


### PR DESCRIPTION
This commit partially ports https://github.com/filecoin-station/voyager-api/pull/22 to this repository:

- Introduce test-helpers and platform-test-helpers
- Rework the test file to use these new helpers
