### PR TITLE
refactor: shared platform-test-helpers

### DIFF
--- a/publish/test/test-helpers.js
+++ b/publish/test/test-helpers.js
@@ -1,4 +1,4 @@
-export * from './platform-test-helpers.js'
+export * from '../../test-helpers/platform-test-helpers.js'
 export * from '../../test-helpers/assert.js'
 
 /**

--- a/test-helpers/platform-test-helpers.js
+++ b/test-helpers/platform-test-helpers.js
@@ -1,7 +1,7 @@
 // This file is shared with voyager-api/voyager-publish
 // Helpers in this file must not have anything project-specific like measurement fields
 
-import { Point } from '../lib/telemetry.js'
+import { Point } from '../publish/lib/telemetry.js'
 
 export const { DATABASE_URL } = process.env
 


### PR DESCRIPTION
Move `platform-test-helpers.js` from `/publish/test` to `/test-helpers` to make then available in `api` tests too.

This is a follow-up for:
- #354
