### PR TITLE
feat: process.env.INFLUXDB_TOKEN

### DIFF
--- a/common/telemetry.js
+++ b/common/telemetry.js
@@ -1,10 +1,18 @@
 import { InfluxDB, Point } from '@influxdata/influxdb-client'
 
+const {
+  INFLUXDB_TOKEN
+} = process.env
+
+if (!INFLUXDB_TOKEN) {
+  console.warn('Warning: INFLUXDB_TOKEN was not provided by the environment')
+}
+
 const influx = new InfluxDB({
   url: 'https://eu-central-1-1.aws.cloud2.influxdata.com',
-  // spark-publish-write
-  token: 'Zkqa_s7mI0W_WKI6DUmu-iRnQkCvwNaQfbPK_zT7I6iYYaC2C1kokdlhO2jb4tjRcAJQHQXAGnrdD3vqlMZ63g=='
+  token: INFLUXDB_TOKEN
 })
+
 const publishWriteClient = influx.getWriteApi(
   'Filecoin Station', // org
   'spark-publish', // bucket


### PR DESCRIPTION
Move the configuration of the writer token from plain-text code to Fly.io secrets.
