### PR TITLE
feat: require spark version >=1.13.0

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -41,7 +41,7 @@ const createMeasurement = async (req, res, client) => {
   validate(measurement, 'sparkVersion', { type: 'string', required: false })
   validate(measurement, 'zinniaVersion', { type: 'string', required: false })
   assert(
-    typeof measurement.sparkVersion === 'string' && satisfies(measurement.sparkVersion, '>=1.9.0'),
+    typeof measurement.sparkVersion === 'string' && satisfies(measurement.sparkVersion, '>=1.13.0'),
     410, 'OUTDATED CLIENT'
   )
 

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -13,7 +13,7 @@ import { delegatedFromEthAddress } from '@glif/filecoin-address'
 
 const { DATABASE_URL } = process.env
 const participantAddress = '0x000000000000000000000000000000000000dEaD'
-const sparkVersion = '1.9.0' // This must be in sync with the minimum supported client version
+const sparkVersion = '1.13.0' // This must be in sync with the minimum supported client version
 const currentSparkRoundNumber = 42n
 
 const VALID_MEASUREMENT = {


### PR DESCRIPTION
Let's force the network to upgrade to the recently release Spark checker version that implements HTTP retrievals directly using the Fetch API.

See https://github.com/filecoin-station/spark/releases/tag/v1.13.0
