### PR TITLE
feat: add `clients` to each task in round details

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -252,6 +252,7 @@ const getMeridianRoundDetails = async (_req, res, client, meridianAddress, merid
     retrievalTasks: tasks.map(t => ({
       cid: t.cid,
       minerId: t.miner_id,
+      clients: t.clients,
       // We are preserving these fields to make older rounds still verifiable
       providerAddress: fixNullToUndefined(t.provider_address),
       protocol: fixNullToUndefined(t.protocol)

--- a/api/lib/round-tracker.js
+++ b/api/lib/round-tracker.js
@@ -257,12 +257,20 @@ export async function maybeCreateSparkRound (pgClient, {
 
 async function defineTasksForRound (pgClient, sparkRoundNumber) {
   await pgClient.query(`
-    INSERT INTO retrieval_tasks (round_id, cid, miner_id)
-    SELECT $1 as round_id, cid, miner_id
-    FROM retrievable_deals
-    WHERE expires_at > now()
-    ORDER BY random()
-    LIMIT $2;
+    INSERT INTO retrieval_tasks (round_id, cid, miner_id, clients)
+    WITH selected AS (
+      SELECT cid, miner_id
+      FROM retrievable_deals
+      WHERE expires_at > now()
+      ORDER BY random()
+      LIMIT $2
+    )
+    SELECT $1 as round_id, selected.cid, selected.miner_id, array_agg(client_id) as clients
+    FROM selected
+    LEFT JOIN retrievable_deals
+    ON selected.cid = retrievable_deals.cid AND selected.miner_id = retrievable_deals.miner_id
+    WHERE retrievable_deals.expires_at > now()
+    GROUP BY selected.cid, selected.miner_id;
   `, [
     sparkRoundNumber,
     TASKS_PER_ROUND

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -444,7 +444,7 @@ describe('Routes', () => {
     })
   })
 
-  describe('GET /round/meridian/:address/:round', () => {
+  describe('GET /rounds/meridian/:address/:round', () => {
     before(async () => {
       await client.query('DELETE FROM meridian_contract_versions')
       await client.query('DELETE FROM spark_rounds')
@@ -492,6 +492,8 @@ describe('Routes', () => {
       for (const task of retrievalTasks) {
         assert.equal(typeof task.cid, 'string', 'all tasks have "cid"')
         assert.equal(typeof task.minerId, 'string', 'all tasks have "minerId"')
+        assert(Array.isArray(task.clients), 'all tasks have "clients" array')
+        assert(task.clients.length > 0, 'all tasks have at least one item in "clients"')
       }
     })
 
@@ -554,6 +556,9 @@ describe('Routes', () => {
 
       for (const t of body.retrievalTasks) {
         assert.strictEqual(typeof t.cid, 'string')
+        assert.equal(typeof t.minerId, 'string', 'all tasks have "minerId"')
+        assert(Array.isArray(t.clients), 'all tasks have "clients" array')
+        assert(t.clients.length > 0, 'all tasks have at least one item in "clients"')
         assert.strictEqual(t.providerAddress, undefined)
         assert.strictEqual(t.protocol, undefined)
       }

--- a/migrations/053.do.tasks-with-clients.sql
+++ b/migrations/053.do.tasks-with-clients.sql
@@ -1,0 +1,2 @@
+ALTER TABLE retrieval_tasks
+ADD COLUMN clients TEXT[];


### PR DESCRIPTION
For each task selected for retrieval tests, add a new field `clients` with a list of client IDs like `f01234` that are storing the same PieceCID/PayloadCID with the same miner.

Note that a single `(cid, miner_id)` pair can and does identify more than one storage deal.

Links:
- https://github.com/filecoin-station/spark/issues/79
