### PR TITLE
feat: get retrievable deals per miner or client

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,58 @@ Response:
 OK
 ```
 
+### `GET /retrievable-deals/miner/:minerId`
+
+Parameters:
+- `minerId` - a miner id like `f0814049`
+
+Response:
+
+Number of deals grouped by client IDs.
+
+```json
+[
+  {
+    "clientId": "f02516933",
+    "dealCount": 6880
+  },
+  {
+    "clientId": "f02833886",
+    "dealCount": 3126
+  },
+  {
+    "clientId": "f02519404",
+    "dealCount": 3114
+  },
+  {
+    "clientId": "f0215074",
+    "dealCount": 758
+  }
+]
+```
+
+### `GET /retrievable-deals/client/:clientId`
+
+Parameters:
+- `clientId` - a client id like `f0215074`
+
+Response:
+
+Number of deals grouped by client IDs.
+
+```json
+[
+  {
+    "minerId": "f0406478",
+    "dealCount": 4592
+  },
+  {
+    "minerId": "f0814049",
+    "dealCount": 758
+  }
+]
+```
+
 ## Development
 
 ### Database

--- a/api/index.js
+++ b/api/index.js
@@ -28,10 +28,10 @@ const handler = async (req, res, client, domain) => {
     await getMeridianRoundDetails(req, res, client, segs[2], segs[3])
   } else if (segs[0] === 'rounds' && req.method === 'GET') {
     await getRoundDetails(req, res, client, segs[1])
-  } else if (segs[0] === 'retrievable-deals' && segs[1] === 'miner' && req.method === 'GET') {
-    await getRetrievableDealsForMiner(req, res, client, segs[2])
-  } else if (segs[0] === 'retrievable-deals' && segs[1] === 'client' && req.method === 'GET') {
-    await getRetrievableDealsForClient(req, res, client, segs[2])
+  } else if (segs[0] === 'miner' && segs[2] === 'retrievable-deals' && segs[3] === 'summary' && req.method === 'GET') {
+    await getRetrievableDealsForMiner(req, res, client, segs[1])
+  } else if (segs[0] === 'client' && segs[2] === 'retrievable-deals' && segs[3] === 'summary' && req.method === 'GET') {
+    await getRetrievableDealsForClient(req, res, client, segs[1])
   } else if (segs[0] === 'inspect-request' && req.method === 'GET') {
     await inspectRequest(req, res)
   } else {
@@ -319,10 +319,15 @@ const getRetrievableDealsForMiner = async (_req, res, client, minerId) => {
   ])
   // Cache the response for 6 hours
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
-  const body = rows.map(
-    // eslint-disable-next-line camelcase
-    ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
-  )
+  const body = {
+    minerId,
+    clients:
+      rows.map(
+        // eslint-disable-next-line camelcase
+        ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
+      )
+  }
+
   json(res, body)
 }
 
@@ -337,10 +342,13 @@ const getRetrievableDealsForClient = async (_req, res, client, clientId) => {
   ])
   // Cache the response for 6 hours
   res.setHeader('cache-control', `max-age=${6 * 3600}`)
-  const body = rows.map(
+  const body = {
+    clientId,
+    providers: rows.map(
     // eslint-disable-next-line camelcase
-    ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
-  )
+      ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
+    )
+  }
   json(res, body)
 }
 

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -647,9 +647,8 @@ describe('Routes', () => {
     })
   })
 
-  describe('/retrievable-deals', () => {
+  describe('retrievable-deals summary', () => {
     before(async () => {
-      // TODO: add expired deals
       await client.query(`
         INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
         VALUES
@@ -668,47 +667,59 @@ describe('Routes', () => {
         ON CONFLICT DO NOTHING
       `)
     })
-    describe('GET /retrievable-deals/miner/{minerId}', () => {
+    describe('GET /miner/{id}/retrievable-deals/summary', () => {
       it('returns deal counts grouped by client id', async () => {
-        const res = await fetch(`${spark}/retrievable-deals/miner/f0230`)
+        const res = await fetch(`${spark}/miner/f0230/retrievable-deals/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
-        assert.deepStrictEqual(body, [
-          { clientId: 'f0800', dealCount: 2 },
-          { clientId: 'f0810', dealCount: 1 },
-          { clientId: 'f0820', dealCount: 1 }
-        ])
+        assert.deepStrictEqual(body, {
+          minerId: 'f0230',
+          clients: [
+            { clientId: 'f0800', dealCount: 2 },
+            { clientId: 'f0810', dealCount: 1 },
+            { clientId: 'f0820', dealCount: 1 }
+          ]
+        })
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(`${spark}/retrievable-deals/miner/f000`)
+        const res = await fetch(`${spark}/miner/f0000/retrievable-deals/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
-        assert.deepStrictEqual(body, [])
+        assert.deepStrictEqual(body, {
+          minerId: 'f0000',
+          clients: []
+        })
       })
     })
 
-    describe('GET /retrievable-deals/client/{clientId}', () => {
+    describe('GET /client/{id}/retrievable-deals/summary', () => {
       it('returns deal counts grouped by miner id', async () => {
-        const res = await fetch(`${spark}/retrievable-deals/client/f0800`)
+        const res = await fetch(`${spark}/client/f0800/retrievable-deals/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
-        assert.deepStrictEqual(body, [
-          { minerId: 'f0230', dealCount: 2 },
-          { minerId: 'f0210', dealCount: 1 },
-          { minerId: 'f0220', dealCount: 1 }
-        ])
+        assert.deepStrictEqual(body, {
+          clientId: 'f0800',
+          providers: [
+            { minerId: 'f0230', dealCount: 2 },
+            { minerId: 'f0210', dealCount: 1 },
+            { minerId: 'f0220', dealCount: 1 }
+          ]
+        })
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(`${spark}/retrievable-deals/client/f000`)
+        const res = await fetch(`${spark}/client/f0000/retrievable-deals/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
-        assert.deepStrictEqual(body, [])
+        assert.deepStrictEqual(body, {
+          clientId: 'f0000',
+          providers: []
+        })
       })
     })
   })

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -676,8 +676,8 @@ describe('Routes', () => {
         const body = await res.json()
         assert.deepStrictEqual(body, [
           { clientId: 'f0800', dealCount: 2 },
-          { clientId: 'f0820', dealCount: 2 },
-          { clientId: 'f0810', dealCount: 1 }
+          { clientId: 'f0810', dealCount: 1 },
+          { clientId: 'f0820', dealCount: 1 }
         ])
       })
 

--- a/migrations/054.do.index-retrievable-deals-client-id.sql
+++ b/migrations/054.do.index-retrievable-deals-client-id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY retrievable_deals_client_id ON retrievable_deals (client_id);

--- a/migrations/055.do.index-retrievable-deals-miner-id.sql
+++ b/migrations/055.do.index-retrievable-deals-miner-id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY retrievable_deals_miner_id ON retrievable_deals (miner_id);


### PR DESCRIPTION
Links:
- https://github.com/filecoin-station/spark-api/pull/386
- https://github.com/filecoin-station/spark/issues/78

Out of the scope of this pull request:

- querying retrievable deals by allocator id

Example request:

```
GET /retrievable-deals/miner/:minerId
```

Example response:

```json
[
  {
    "clientId": "f02516933",
    "dealCount": 6880
  },
  {
    "clientId": "f02833886",
    "dealCount": 3126
  }
]
```

Example request:

```
GET /retrievable-deals/client/:clientId
```

Example response:

```json
[
  {
    "minerId": "f0406478",
    "dealCount": 4592
  },
  {
    "minerId": "f0814049",
    "dealCount": 758
  }
]
```
