### PR TITLE
feat: API for deals tracked per miner/client/allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Response:
 OK
 ```
 
-### `GET /miner/:id/deals/eligible/summary`
+### `GET /miner/:minerId/deals/eligible/summary`
 
 Parameters:
 - `minerId` - a miner id like `f0814049`
@@ -78,7 +78,7 @@ Number of deals grouped by client IDs.
 }
 ```
 
-### `GET /client/:id/deals/eligible/summary`
+### `GET /client/:clientId/deals/eligible/summary`
 
 Parameters:
 - `clientId` - a client id like `f0215074`
@@ -98,7 +98,7 @@ Number of deals grouped by miner IDs.
 }
 ```
 
-### `GET /allocator/:id/deals/eligible/summary`
+### `GET /allocator/:allocatorId/deals/eligible/summary`
 
 Parameters:
 - `allocatorId` - an allocator id like `f03015751`

--- a/README.md
+++ b/README.md
@@ -110,6 +110,32 @@ Number of deals grouped by miner IDs.
 }
 ```
 
+### `GET /allocator/:id/deals/eligible/summary`
+
+Parameters:
+- `allocatorId` - an allocator id like `f03015751`
+
+Response:
+
+Number of deals grouped by miner IDs.
+
+```json
+{
+  "allocatorId": "f03015751",
+  "dealCount": 4088,
+  "clients": [
+    {
+      "clientId": "f03144229",
+      "dealCount": 2488
+    },
+    {
+      "clientId": "f03150656",
+      "dealCount": 1600
+    }
+  ]
+}
+```
+
 ## Development
 
 ### Database

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Response:
 OK
 ```
 
-### `GET /retrievable-deals/miner/:minerId`
+### `GET /miner/:id/deals/eligible/summary`
 
 Parameters:
 - `minerId` - a miner id like `f0814049`
@@ -68,46 +68,46 @@ Response:
 Number of deals grouped by client IDs.
 
 ```json
-[
-  {
-    "clientId": "f02516933",
-    "dealCount": 6880
-  },
-  {
-    "clientId": "f02833886",
-    "dealCount": 3126
-  },
-  {
-    "clientId": "f02519404",
-    "dealCount": 3114
-  },
-  {
-    "clientId": "f0215074",
-    "dealCount": 758
-  }
-]
+{
+  "minerId": "f0814049",
+  "dealCount": 13878,
+  "clients": [
+    {
+      "clientId": "f02516933",
+      "dealCount": 6880
+    },
+    {
+      "clientId": "f02833886",
+      "dealCount": 3126
+    }
+  ]
+}
 ```
 
-### `GET /retrievable-deals/client/:clientId`
+### `GET /client/:id/deals/eligible/summary`
 
 Parameters:
 - `clientId` - a client id like `f0215074`
 
 Response:
 
-Number of deals grouped by client IDs.
+Number of deals grouped by miner IDs.
 
 ```json
-[
-  {
-    "minerId": "f0406478",
-    "dealCount": 4592
-  },
-  {
-    "minerId": "f0814049",
-    "dealCount": 758
-  }
-]
+{
+  "clientId": "f0215074",
+  "dealCount": 38977,
+  "providers": [
+    {
+      "minerId": "f01975316",
+      "dealCount": 6810
+    },
+    {
+      "minerId": "f01975326",
+      "dealCount": 6810
+    }
+  ]
+}
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -58,6 +58,58 @@ Response:
 OK
 ```
 
+### `GET /retrievable-deals/miner/:minerId`
+
+Parameters:
+- `minerId` - a miner id like `f0814049`
+
+Response:
+
+Number of deals grouped by client IDs.
+
+```json
+[
+  {
+    "clientId": "f02516933",
+    "dealCount": 6880
+  },
+  {
+    "clientId": "f02833886",
+    "dealCount": 3126
+  },
+  {
+    "clientId": "f02519404",
+    "dealCount": 3114
+  },
+  {
+    "clientId": "f0215074",
+    "dealCount": 758
+  }
+]
+```
+
+### `GET /retrievable-deals/client/:clientId`
+
+Parameters:
+- `clientId` - a client id like `f0215074`
+
+Response:
+
+Number of deals grouped by client IDs.
+
+```json
+[
+  {
+    "minerId": "f0406478",
+    "dealCount": 4592
+  },
+  {
+    "minerId": "f0814049",
+    "dealCount": 758
+  }
+]
+```
+
 ## Development
 
 ### Database

--- a/README.md
+++ b/README.md
@@ -72,14 +72,8 @@ Number of deals grouped by client IDs.
   "minerId": "f0814049",
   "dealCount": 13878,
   "clients": [
-    {
-      "clientId": "f02516933",
-      "dealCount": 6880
-    },
-    {
-      "clientId": "f02833886",
-      "dealCount": 3126
-    }
+    { "clientId": "f02516933", "dealCount": 6880 },
+    { "clientId": "f02833886", "dealCount": 3126 }
   ]
 }
 ```
@@ -98,14 +92,8 @@ Number of deals grouped by miner IDs.
   "clientId": "f0215074",
   "dealCount": 38977,
   "providers": [
-    {
-      "minerId": "f01975316",
-      "dealCount": 6810
-    },
-    {
-      "minerId": "f01975326",
-      "dealCount": 6810
-    }
+    { "minerId": "f01975316", "dealCount": 6810 },
+    { "minerId": "f01975326", "dealCount": 6810 }
   ]
 }
 ```
@@ -117,21 +105,15 @@ Parameters:
 
 Response:
 
-Number of deals grouped by miner IDs.
+Number of deals grouped by client IDs.
 
 ```json
 {
   "allocatorId": "f03015751",
   "dealCount": 4088,
   "clients": [
-    {
-      "clientId": "f03144229",
-      "dealCount": 2488
-    },
-    {
-      "clientId": "f03150656",
-      "dealCount": 1600
-    }
+    { "clientId": "f03144229", "dealCount": 2488 },
+    { "clientId": "f03150656", "dealCount": 1600 }
   ]
 }
 ```

--- a/api/index.js
+++ b/api/index.js
@@ -28,6 +28,10 @@ const handler = async (req, res, client, domain) => {
     await getMeridianRoundDetails(req, res, client, segs[2], segs[3])
   } else if (segs[0] === 'rounds' && req.method === 'GET') {
     await getRoundDetails(req, res, client, segs[1])
+  } else if (segs[0] === 'miner' && segs[2] === 'retrievable-deals' && segs[3] === 'summary' && req.method === 'GET') {
+    await getRetrievableDealsForMiner(req, res, client, segs[1])
+  } else if (segs[0] === 'client' && segs[2] === 'retrievable-deals' && segs[3] === 'summary' && req.method === 'GET') {
+    await getRetrievableDealsForClient(req, res, client, segs[1])
   } else if (segs[0] === 'inspect-request' && req.method === 'GET') {
     await inspectRequest(req, res)
   } else {
@@ -302,6 +306,50 @@ const redirect = (res, location) => {
   res.statusCode = 301
   res.setHeader('location', location)
   res.end()
+}
+
+const getRetrievableDealsForMiner = async (_req, res, client, minerId) => {
+  const { rows } = await client.query(`
+    SELECT client_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
+    WHERE miner_id = $1 AND expires_at > now()
+    GROUP BY client_id
+    ORDER BY deal_count DESC, client_id ASC
+    `, [
+    minerId
+  ])
+  // Cache the response for 6 hours
+  res.setHeader('cache-control', `max-age=${6 * 3600}`)
+  const body = {
+    minerId,
+    clients:
+      rows.map(
+        // eslint-disable-next-line camelcase
+        ({ client_id, deal_count }) => ({ clientId: client_id, dealCount: deal_count })
+      )
+  }
+
+  json(res, body)
+}
+
+const getRetrievableDealsForClient = async (_req, res, client, clientId) => {
+  const { rows } = await client.query(`
+    SELECT miner_id, COUNT(cid)::INTEGER as deal_count FROM retrievable_deals
+    WHERE client_id = $1 AND expires_at > now()
+    GROUP BY miner_id
+    ORDER BY deal_count DESC, miner_id ASC
+    `, [
+    clientId
+  ])
+  // Cache the response for 6 hours
+  res.setHeader('cache-control', `max-age=${6 * 3600}`)
+  const body = {
+    clientId,
+    providers: rows.map(
+    // eslint-disable-next-line camelcase
+      ({ miner_id, deal_count }) => ({ minerId: miner_id, dealCount: deal_count })
+    )
+  }
+  json(res, body)
 }
 
 export const inspectRequest = async (req, res) => {

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -647,34 +647,32 @@ describe('Routes', () => {
     })
   })
 
-  describe('retrievable-deals summary', () => {
+  describe('summary of eligible deals', () => {
     before(async () => {
       await client.query(`
         INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
         VALUES
         ('bafyone', 'f0210', 'f0800', '2100-01-01'),
-
         ('bafyone', 'f0220', 'f0800', '2100-01-01'),
         ('bafytwo', 'f0220', 'f0810', '2100-01-01'),
-
         ('bafyone', 'f0230', 'f0800', '2100-01-01'),
         ('bafytwo', 'f0230', 'f0800', '2100-01-01'),
         ('bafythree', 'f0230', 'f0810', '2100-01-01'),
         ('bafyfour', 'f0230', 'f0820', '2100-01-01'),
-
         ('bafyexpired', 'f0230', 'f0800', '2020-01-01')
-
         ON CONFLICT DO NOTHING
       `)
     })
-    describe('GET /miner/{id}/retrievable-deals/summary', () => {
+
+    describe('GET /miner/{id}/deals/eligible/summary', () => {
       it('returns deal counts grouped by client id', async () => {
-        const res = await fetch(`${spark}/miner/f0230/retrievable-deals/summary`)
+        const res = await fetch(`${spark}/miner/f0230/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
         assert.deepStrictEqual(body, {
           minerId: 'f0230',
+          dealCount: 4,
           clients: [
             { clientId: 'f0800', dealCount: 2 },
             { clientId: 'f0810', dealCount: 1 },
@@ -684,25 +682,27 @@ describe('Routes', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(`${spark}/miner/f0000/retrievable-deals/summary`)
+        const res = await fetch(`${spark}/miner/f0000/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
         assert.deepStrictEqual(body, {
           minerId: 'f0000',
+          dealCount: 0,
           clients: []
         })
       })
     })
 
-    describe('GET /client/{id}/retrievable-deals/summary', () => {
+    describe('GET /client/{id}/deals/eligible/summary', () => {
       it('returns deal counts grouped by miner id', async () => {
-        const res = await fetch(`${spark}/client/f0800/retrievable-deals/summary`)
+        const res = await fetch(`${spark}/client/f0800/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
         assert.deepStrictEqual(body, {
           clientId: 'f0800',
+          dealCount: 4,
           providers: [
             { minerId: 'f0230', dealCount: 2 },
             { minerId: 'f0210', dealCount: 1 },
@@ -712,12 +712,13 @@ describe('Routes', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(`${spark}/client/f0000/retrievable-deals/summary`)
+        const res = await fetch(`${spark}/client/f0000/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()
         assert.deepStrictEqual(body, {
           clientId: 'f0000',
+          dealCount: 0,
           providers: []
         })
       })

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -750,7 +750,7 @@ describe('Routes', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-      const res = await fetch(`${spark}/allocator/f0000/deals/eligible/summary`)
+        const res = await fetch(`${spark}/allocator/f0000/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -646,4 +646,81 @@ describe('Routes', () => {
       }
     })
   })
+
+  describe('retrievable-deals summary', () => {
+    before(async () => {
+      await client.query(`
+        INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at)
+        VALUES
+        ('bafyone', 'f0210', 'f0800', '2100-01-01'),
+
+        ('bafyone', 'f0220', 'f0800', '2100-01-01'),
+        ('bafytwo', 'f0220', 'f0810', '2100-01-01'),
+
+        ('bafyone', 'f0230', 'f0800', '2100-01-01'),
+        ('bafytwo', 'f0230', 'f0800', '2100-01-01'),
+        ('bafythree', 'f0230', 'f0810', '2100-01-01'),
+        ('bafyfour', 'f0230', 'f0820', '2100-01-01'),
+
+        ('bafyexpired', 'f0230', 'f0800', '2020-01-01')
+
+        ON CONFLICT DO NOTHING
+      `)
+    })
+    describe('GET /miner/{id}/retrievable-deals/summary', () => {
+      it('returns deal counts grouped by client id', async () => {
+        const res = await fetch(`${spark}/miner/f0230/retrievable-deals/summary`)
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          minerId: 'f0230',
+          clients: [
+            { clientId: 'f0800', dealCount: 2 },
+            { clientId: 'f0810', dealCount: 1 },
+            { clientId: 'f0820', dealCount: 1 }
+          ]
+        })
+      })
+
+      it('returns an empty array for miners with no deals in our DB', async () => {
+        const res = await fetch(`${spark}/miner/f0000/retrievable-deals/summary`)
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          minerId: 'f0000',
+          clients: []
+        })
+      })
+    })
+
+    describe('GET /client/{id}/retrievable-deals/summary', () => {
+      it('returns deal counts grouped by miner id', async () => {
+        const res = await fetch(`${spark}/client/f0800/retrievable-deals/summary`)
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          clientId: 'f0800',
+          providers: [
+            { minerId: 'f0230', dealCount: 2 },
+            { minerId: 'f0210', dealCount: 1 },
+            { minerId: 'f0220', dealCount: 1 }
+          ]
+        })
+      })
+
+      it('returns an empty array for miners with no deals in our DB', async () => {
+        const res = await fetch(`${spark}/client/f0000/retrievable-deals/summary`)
+        await assertResponseStatus(res, 200)
+        assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
+        const body = await res.json()
+        assert.deepStrictEqual(body, {
+          clientId: 'f0000',
+          providers: []
+        })
+      })
+    })
+  })
 })

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -750,7 +750,7 @@ describe('Routes', () => {
       })
 
       it('returns an empty array for miners with no deals in our DB', async () => {
-        const res = await fetch(`${spark}/allocator/f0000/deals/eligible/summary`)
+      const res = await fetch(`${spark}/allocator/f0000/deals/eligible/summary`)
         await assertResponseStatus(res, 200)
         assert.strictEqual(res.headers.get('cache-control'), 'max-age=21600')
         const body = await res.json()


### PR DESCRIPTION
This pull request moves the implementation of REST API exposing deals eligible for testing from spark-stats to spark-api, as discussed in https://github.com/filecoin-station/spark-stats/pull/194#discussion_r1713500083

Links:
- https://github.com/filecoin-station/spark-stats/pull/194
- https://github.com/filecoin-station/spark-stats/pull/196
- https://github.com/filecoin-station/spark-api/pull/388
- https://github.com/filecoin-station/spark/issues/78

Example request:

```
GET /miner/f0814049/deals/eligible/summary
```

Example response:

```json
{
  "minerId": "f0814049",
  "dealCount": 10006,
  "clients": [
    { "clientId": "f02516933", "dealCount": 6880 },
    { "clientId": "f02833886", "dealCount": 3126 }
  ]
}
```

Example request:

```
GET /clients/f0215074/deals/eligible/summary
```

Example response:

```json
{
  "clientId": "f0215074",
  "dealCount": 5350,
  "providers": [
    { "minerId": "f0406478", "dealCount": 4592 },
    { "minerId": "f0814049", "dealCount": 758 }
  ]
}
```

Example request:

```
GET /allocator/f03015751/deals/eligible/summary
```

Example response:

```json
{
  "allocatorId": "f03019831",
  "dealCount": 117596,
  "clients": [
    { "clientId": "f02056762", "dealCount": 64674 },
    { "clientId": "f03146638", "dealCount": 21405 }
  ]
}
```
