### PR TITLE
fix: accept measurements with `startAt: null`

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -71,7 +71,7 @@ const createMeasurement = async (req, res, client) => {
   validate(measurement, 'protocol', { type: 'string', required: false })
   validate(measurement, 'participantAddress', { type: 'ethereum address', required: true })
   validate(measurement, 'timeout', { type: 'boolean', required: false })
-  validate(measurement, 'startAt', { type: 'date', required: true })
+  validate(measurement, 'startAt', { type: 'date', required: false })
   validate(measurement, 'statusCode', { type: 'number', required: false })
   validate(measurement, 'firstByteAt', { type: 'date', required: false })
   validate(measurement, 'endAt', { type: 'date', required: false })

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -262,6 +262,7 @@ describe('Routes', () => {
       const measurement = {
         ...VALID_MEASUREMENT,
         statusCode: undefined,
+        startAt: null,
         firstByteAt: null,
         endAt: null
       }
@@ -283,6 +284,7 @@ describe('Routes', () => {
       ])
 
       assert.strictEqual(measurementRow.status_code, null)
+      assert.strictEqual(measurementRow.start_at, null)
       assert.strictEqual(measurementRow.first_byte_at, null)
       assert.strictEqual(measurementRow.end_at, null)
     })

--- a/migrations/057.do.nullable-measurement-start-at.sql
+++ b/migrations/057.do.nullable-measurement-start-at.sql
@@ -1,0 +1,3 @@
+ALTER TABLE measurements
+ALTER COLUMN start_at
+DROP NOT NULL;


### PR DESCRIPTION
This is a follow-up for https://github.com/filecoin-station/spark/pull/92
