### PR TITLE
feat: record row-count & round index of commitments

### DIFF
--- a/migrations/059.do.commitments-size-round.sql
+++ b/migrations/059.do.commitments-size-round.sql
@@ -1,0 +1,3 @@
+ALTER TABLE commitments ADD COLUMN measurement_count BIGINT;
+ALTER TABLE commitments ADD COLUMN meridian_address TEXT;
+ALTER TABLE commitments ADD COLUMN meridian_round BIGINT;

--- a/publish/index.js
+++ b/publish/index.js
@@ -83,10 +83,19 @@ export const publish = async ({
       measurements.map(m => m.id)
     ])
 
-    // Record the commitment for future queries
-    // TODO: store also ieContract.address and roundIndex
-    await pgClient.query('INSERT INTO commitments (cid, published_at) VALUES ($1, $2)', [
-      cid.toString(), new Date()
+    await pgClient.query(`
+      INSERT INTO commitments (
+        cid,
+        published_at,
+        measurement_count,
+        meridian_address,
+        meridian_round
+      ) VALUES ($1, now(), $2, $3, $4)
+    `, [
+      cid.toString(),
+      measurements.length,
+      SparkImpactEvaluator.ADDRESS,
+      roundIndex
     ])
 
     await pgClient.query(`

--- a/publish/test/test.js
+++ b/publish/test/test.js
@@ -175,6 +175,7 @@ describe('integration', () => {
     }
 
     // TODO: Figure out how to use anvil here
+    const commitmentRoundIndex = 99
     const ieContractMeasurementCIDs = []
     const ieContract = {
       async addMeasurements (_cid) {
@@ -195,7 +196,7 @@ describe('integration', () => {
           return {
             args: [
               null,
-              1
+              commitmentRoundIndex
             ]
           }
         }
@@ -240,7 +241,15 @@ describe('integration', () => {
     assert.strictEqual(published.participant_address, '0x000000000000000000000000000000000000dEaD')
 
     const { rows: commitments } = await client.query('SELECT * FROM commitments')
-    assert.deepStrictEqual(commitments.map(c => c.cid), [cid])
+    // eslint-disable-next-line camelcase
+    assert.deepStrictEqual(commitments.map(({ published_at, ...cols }) => cols), [
+      {
+        cid,
+        measurement_count: '2',
+        meridian_address: SparkImpactEvaluator.ADDRESS,
+        meridian_round: String(commitmentRoundIndex)
+      }
+    ])
     assertApproximately(commitments[0].published_at, new Date(), 1_000 /* milliseconds */)
 
     // Check that published measurements were deleted and measurements added later were preserved


### PR DESCRIPTION
From time to time, when troubleshooting issues or trying to backfill statistics we don't collect, I wish we stored more information about commitments in our database.

In this pull request, I am adding three new columns:
- `measurement_count`
- `meridian_address`
- `meridian_round`

Note: It would be more efficient storage-wise to map meridian address+round to spark round number (reference `spark_rounds.id`). However, in the current implementation, when a commitment is added to a new round, we may not have a row in `spark_rounds` created yet. Changing that is out of scope of this pull request.

Related discussions:
- https://space-meridian.slack.com/archives/C06RPCL6QGL/p1726662716781129