### PR TITLE
publish: add assert logs were emitted. #421

### DIFF
--- a/publish/index.js
+++ b/publish/index.js
@@ -142,6 +142,7 @@ const commitMeasurements = async ({ cid, ieContract, logger }) => {
   const tx = await ieContract.addMeasurements(cid.toString())
   logger.log('Waiting for the transaction receipt:', tx.hash)
   const receipt = await tx.wait()
+  assert(receipt.logs.length > 0, 'No logs found in the receipt')
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]
   const ieAddMeasurementsDuration = new Date() - start

--- a/publish/index.js
+++ b/publish/index.js
@@ -142,7 +142,11 @@ const commitMeasurements = async ({ cid, ieContract, logger }) => {
   const tx = await ieContract.addMeasurements(cid.toString())
   logger.log('Waiting for the transaction receipt:', tx.hash)
   const receipt = await tx.wait()
-  assert(receipt.logs.length > 0, 'No logs found in the receipt')
+  if (receipt.logs.length === 0) {
+    const err = new Error('No logs found in the receipt')
+    err.receipt = receipt
+    throw err
+  }
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]
   const ieAddMeasurementsDuration = new Date() - start


### PR DESCRIPTION
This will help us solve #421, as
- we have a more semantic error message
- `receipt` is attached to the error, for inspection