### PR TITLE
remove chainup (fix ci)

### DIFF
--- a/common/ie-contract-config.js
+++ b/common/ie-contract-config.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 
 const {
-  RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1,https://filecoin.chainup.net/rpc/v1',
+  RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1',
   GLIF_TOKEN
 } = process.env
 


### PR DESCRIPTION
I believe chainup is responsible for the CI errors:

> JsonRpcProvider failed to detect network and cannot start up; retry in 1s (perhaps the URL is wrong or the node is not started)