### PR TITLE
ie-contract: Disable JSON-RPC polling

### DIFF
--- a/api/lib/ie-contract.js
+++ b/api/lib/ie-contract.js
@@ -5,7 +5,7 @@ import * as SparkImpactEvaluator from '@filecoin-station/spark-impact-evaluator'
 const provider = new ethers.FallbackProvider(rpcUrls.map(rpcUrl => {
   const fetchRequest = new ethers.FetchRequest(rpcUrl)
   fetchRequest.setHeader('Authorization', `Bearer ${GLIF_TOKEN}`)
-  return new ethers.JsonRpcProvider(fetchRequest, null, { polling: true })
+  return new ethers.JsonRpcProvider(fetchRequest)
 }))
 
 // Uncomment for troubleshooting


### PR DESCRIPTION
This makes us use `eth_getFilterChanges` which should now work. If it doesn't, this will let us give feedback.

See also https://github.com/filecoin-station/spark-evaluate/pull/399