### PR TITLE
feat: drop table `retrievable_deals`

### DIFF
--- a/migrations/064.do.drop-retrievable-deals.sql
+++ b/migrations/064.do.drop-retrievable-deals.sql
@@ -1,0 +1,1 @@
+DROP TABLE retrievable_deals;


### PR DESCRIPTION
This is a follow-up for #486 where we started using `eligible_deals` instead.

Close https://github.com/filecoin-station/fil-deal-ingester/issues/29
