### PR TITLE
feat: POST /eligible-deals-batch

### DIFF
--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -1,4 +1,5 @@
 import '../lib/instrument.js'
+import assert from 'node:assert'
 import http from 'node:http'
 import { once } from 'node:events'
 import { createHandler } from '../index.js'
@@ -13,8 +14,11 @@ const {
   HOST = '127.0.0.1',
   DOMAIN = 'localhost',
   DATABASE_URL,
+  DEAL_INGESTER_TOKEN,
   REQUEST_LOGGING = 'true'
 } = process.env
+
+assert(DEAL_INGESTER_TOKEN, 'DEAL_INGESTER_TOKEN is required')
 
 const client = new pg.Pool({
   connectionString: DATABASE_URL,
@@ -68,6 +72,7 @@ const logger = {
 const handler = await createHandler({
   client,
   logger,
+  dealIngestionAccessToken: DEAL_INGESTER_TOKEN,
   domain: DOMAIN
 })
 const server = http.createServer(handler)

--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -18,6 +18,10 @@ const {
   REQUEST_LOGGING = 'true'
 } = process.env
 
+// This token is used by other Spark services to authenticate requests adding new deals
+// to Spark's database of deals eligible for retrieval testing (`POST /eligible-deals-batch`).
+// In production, the value is configured using Fly.io secrets (`fly secrets`).
+// The same token is configured in Fly.io secrets for the deal-observer service too.
 assert(DEAL_INGESTER_TOKEN, 'DEAL_INGESTER_TOKEN is required')
 
 const client = new pg.Pool({

--- a/api/index.js
+++ b/api/index.js
@@ -36,7 +36,7 @@ const handler = async (req, res, client, domain) => {
     await getSummaryOfEligibleDealsForAllocator(req, res, client, segs[1])
   } else if (segs[0] === 'inspect-request' && req.method === 'GET') {
     await inspectRequest(req, res)
-  } else if (segs[0] === 'ingest-eligible-deals' && req.method === 'POST') {
+  } else if (segs[0] === 'eligible-deals-batch' && req.method === 'POST') {
     await ingestEligibleDeals(req, res, client)
   } else {
     notFound(res)

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -783,9 +783,14 @@ describe('Routes', () => {
     })
 
     it('ingests new deals', async () => {
+      // A miner ID value not found in real data
+      const TEST_MINER_ID = 'f000'
+      // A client ID value not found in real data
+      const TEST_CLIENT_ID = 'f001'
+
       const deals = [{
-        minerId: 'f000',
-        clientId: 'f001',
+        minerId: TEST_MINER_ID,
+        clientId: TEST_CLIENT_ID,
         pieceCid: 'bagaone',
         pieceSize: '34359738368',
         payloadCid: 'bafyone',
@@ -806,8 +811,8 @@ describe('Routes', () => {
         ['f000']
       )
       assert.deepStrictEqual(rows, [{
-        miner_id: 'f000',
-        client_id: 'f001',
+        miner_id: TEST_MINER_ID,
+        client_id: TEST_CLIENT_ID,
         piece_cid: 'bagaone',
         piece_size: '34359738368',
         payload_cid: 'bafyone',

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -774,7 +774,7 @@ describe('Routes', () => {
     })
   })
 
-  describe('POST /ingest-eligible-deals', () => {
+  describe('POST /eligible-deals-batch', () => {
     beforeEach(async () => {
       await client.query(
         'DELETE FROM eligible_deals WHERE miner_id = $1',
@@ -797,7 +797,7 @@ describe('Routes', () => {
         expiresAt: '2100-01-01'
       }]
 
-      const res = await fetch(`${spark}/ingest-eligible-deals`, {
+      const res = await fetch(`${spark}/eligible-deals-batch`, {
         method: 'POST',
         body: JSON.stringify(deals)
       })
@@ -826,7 +826,7 @@ describe('Routes', () => {
         'SELECT * FROM eligible_deals WHERE sourced_from_f05_state = TRUE LIMIT 1'
       )
 
-      const res = await fetch(`${spark}/ingest-eligible-deals`, {
+      const res = await fetch(`${spark}/eligible-deals-batch`, {
         method: 'POST',
         body: JSON.stringify([{
           minerId: f05Deal.miner_id,


### PR DESCRIPTION
See https://github.com/space-meridian/roadmap/issues/218

Create a new API endpoint allowing trusted clients like deal-observer to add
more deals to the list of deals eligible for retrieval testing.

TODO:
- [x] access-token-based authorization
