### PR TITLE
chore: Listen on IPv6 by default

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -8,7 +8,9 @@ processes = []
 
 [env]
   PORT = "8080"
-  HOST = "0.0.0.0"
+  # Listen on IPv6 by default
+  # https://fly.io/docs/networking/private-networking/#listening-for-connections-on-6pn-addresses
+  HOST = "::"
   SENTRY_ENVIRONMENT = "production"
   DOMAIN = "api.filspark.com"
   REQUEST_LOGGING = "false"


### PR DESCRIPTION
According to fly.io documentation internal services should listen on IPv6 by default.