### PR TITLE
publish: fix noop when no measurements

### DIFF
--- a/publish/index.js
+++ b/publish/index.js
@@ -43,6 +43,10 @@ export const publish = async ({
   `, [
     maxMeasurements
   ])
+  if (measurements.length === 0) {
+    logger.log('No measurements to publish.')
+    return
+  }
 
   // Fetch the count of all unpublished measurements - we need this for monitoring
   // Note: this number will be higher than `measurements.length` because spark-api adds more


### PR DESCRIPTION
Prevent publishing an empty batch:

> spark-publish Publishing 0 measurements. Total unpublished: 0. Batch size: 100000.
> spark-publish Measurements packaged in bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku